### PR TITLE
Add the possibility to set `id` attribute on Telnyx::Call object

### DIFF
--- a/lib/telnyx/call.rb
+++ b/lib/telnyx/call.rb
@@ -5,8 +5,14 @@ module Telnyx
     extend Telnyx::APIOperations::Create
     extend Telnyx::APIOperations::NestedResource
 
+    attr_writer :id
+
     def id
-      call_control_id
+      if respond_to?(:call_control_id)
+        call_control_id
+      else
+        @id
+      end
     end
 
     ACTIONS = %w[reject answer hangup bridge speak fork_start fork_stop


### PR DESCRIPTION
Since the `id` can be `call_control_id` after `Telnyx::Call.create`,
which is generated dynamically after this call, we need to check its
definition in order to be able to initialize an empty object.

With this, we should be able to do the following:

call = Telnyx::Call.new
call.id = "some-id"

But the `id` attribute will always assume the `call_control_id` coming
from the request after running `Telnyx::Call.create`.