### PR TITLE
Use string interpolation for suffixing a space to error titles.

### DIFF
--- a/lib/telnyx/errors.rb
+++ b/lib/telnyx/errors.rb
@@ -46,7 +46,7 @@ module Telnyx
     def message
       case @errors
       when Array
-        @errors[0]["title"] + " "
+        "#{@errors[0]['title']} "
       else
         @errors
       end


### PR DESCRIPTION
This prevents `TelnyxError#message` from blowing up when an error
hash, for whatever reason, doesn't have a `'title'` key.