### PR TITLE
Raise proactively when `id` is `nil`.

### DIFF
--- a/lib/telnyx/api_operations/nested_resource.rb
+++ b/lib/telnyx/api_operations/nested_resource.rb
@@ -19,6 +19,7 @@ module Telnyx
 
         resource_url_method = :"#{resource}s_url"
         define_singleton_method(resource_url_method) do |id, nested_id = nil|
+          raise ArgumentError, 'id is required' if id.nil?
           url = "#{resource_url}/#{CGI.escape(id)}/#{path}"
           url += "/#{CGI.escape(nested_id)}" unless nested_id.nil?
           url


### PR DESCRIPTION
This ends up throwing when you call `CGI.escape(nil)` anyway.
This way, the error is much more helpful.