### PR TITLE
fix sim response errors

### DIFF
--- a/lib/telnyx/util.rb
+++ b/lib/telnyx/util.rb
@@ -79,7 +79,7 @@ module Telnyx
         # Try converting to a known object class. If none available, fall back to generic TelnyxObject
         if data[:data].is_a?(Array)
           ListObject.construct_from(data, opts)
-        elsif data[:data] && data[:data][:record_type]
+        elsif data[:data].is_a?(Hash) && data[:data][:record_type]
           object_classes.fetch(data[:data][:record_type], TelnyxObject).construct_from(data[:data], opts)
         elsif data[:record_type]
           object_classes.fetch(data[:record_type], TelnyxObject).construct_from(data, opts)

--- a/test/telnyx/sim_card_test.rb
+++ b/test/telnyx/sim_card_test.rb
@@ -29,27 +29,15 @@ module Telnyx
 
     context "actions" do
       should "deactivate" do
-        stub_request(:get, "#{Telnyx.api_base}/v2/sim_cards/123")
-          .to_return(body: JSON.generate(data: { record_type: "sim_card", id: "123" }))
-
-        stub = stub_request(:post, "#{Telnyx.api_base}/v2/sim_cards/123/actions/deactivate")
-               .to_return(body: JSON.generate(errors: []), status: 202)
-
         sim = Telnyx::SimCard.retrieve "123"
         sim.deactivate
-        assert_requested stub
+        assert_requested(:post, "#{Telnyx.api_base}/v2/sim_cards/123/actions/deactivate")
       end
 
       should "activate" do
-        stub_request(:get, "#{Telnyx.api_base}/v2/sim_cards/123")
-          .to_return(body: JSON.generate(data: { record_type: "sim_card", id: "123" }))
-
-        stub = stub_request(:post, "#{Telnyx.api_base}/v2/sim_cards/123/actions/activate")
-               .to_return(body: JSON.generate(errors: []), status: 202)
-
         sim = Telnyx::SimCard.retrieve "123"
         sim.activate
-        assert_requested stub
+        assert_requested(:post, "#{Telnyx.api_base}/v2/sim_cards/123/actions/activate")
       end
     end
   end


### PR DESCRIPTION
Fixes bug in `util.rb` in which `TelnyxObject` creation fails if a blank
response is received from the server.

Remove mocking from `sim_card_test.rb`