### PR TITLE
net-http-persistent: loosen version requirements

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7']
+        ruby: [ '2.5', '2.6', '2.7', '3.0']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,16 +20,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7' ]
+        ruby: [ '2.5', '2.6', '2.7']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
     # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@21351ecc0a7c196081abca5dc55b08f085efe09a
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: ${{ matrix.ruby }}
     - name: Run Setup Script to install mock
       run: source ./.github/scripts/before_install.sh
       shell: bash

--- a/telnyx.gemspec
+++ b/telnyx.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   }
 
   s.add_dependency("faraday", "~> 0.13", "!= 0.16.0", "!= 0.16.1", "!= 0.16.2")
-  s.add_dependency("net-http-persistent", "~> 3.0")
+  s.add_dependency("net-http-persistent", ">= 3.0", "< 5.0")
   s.add_dependency("ed25519", "~> 1")
 
   s.files = `git ls-files`.split("\n")


### PR DESCRIPTION
Versions of net-http-persistent less than 4.0.1 require a ruby version of '~> 2.3', which means that it will not install under ruby 3.0.
Loosen the requirement on net-http-persistent from 3.x to 3.x-4.x, allowing telnyx-ruby to be installable under ruby 3.0.

See: [net-http-persistent changelog](https://github.com/drbrain/net-http-persistent/blob/master/History.txt) -- there is one minor breaking change between 3.x and 4.x, but it doesn't appear that this library uses or relies on that functionality. 