### PR TITLE
Fix incorrect ruby versions in CI.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,9 +27,9 @@ jobs:
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
     # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@21351ecc0a7c196081abca5dc55b08f085efe09a
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: ${{ matrix.ruby }}
     - name: Run Setup Script to install mock
       run: source ./.github/scripts/before_install.sh
       shell: bash

--- a/test/telnyx/fqdn_connection_test.rb
+++ b/test/telnyx/fqdn_connection_test.rb
@@ -12,7 +12,7 @@ module Telnyx
     end
 
     should "create fqdn connection" do
-      FQDNConnection.create
+      FQDNConnection.create(connection_name: "test")
       assert_requested :post, "#{Telnyx.api_base}/v2/fqdn_connections"
     end
 

--- a/test/telnyx/fqdn_test.rb
+++ b/test/telnyx/fqdn_test.rb
@@ -12,7 +12,7 @@ module Telnyx
     end
 
     should "create fqdn" do
-      FQDN.create fqdn: "example.com"
+      FQDN.create fqdn: "example.com", dns_record_type: "A", connection_id: "abc"
       assert_requested :post, "#{Telnyx.api_base}/v2/fqdns"
     end
 


### PR DESCRIPTION
* Change setup-ruby action to `@v1` instead of a commit SHA.
* Fix ruby-version reference -- the current setup actually runs the  tests three times on ruby 2.6 each time.  Instead it should reference the matrix.ruby version.  You can confirm this by checking the test run of some other branch -- notice that the path when running bundle includes `2.6.x` every time.