### PR TITLE
Faraday dependency: allow using 1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 group :development do
   gem "coveralls", require: false
-  gem "faraday", "0.17.3"
+  gem "faraday", "~> 1.0"
   gem "mocha", "~> 0.13.2"
   gem "rake"
   gem "shoulda-context"

--- a/lib/telnyx/telnyx_client.rb
+++ b/lib/telnyx/telnyx_client.rb
@@ -240,7 +240,7 @@ module Telnyx
         end
 
         case e
-        when Faraday::ClientError
+        when Faraday::Error
           if e.response
             handle_error_response(e.response, error_context)
           else

--- a/telnyx.gemspec
+++ b/telnyx.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     "source_code_uri"   => "https://github.com/team-telnyx/telnyx-ruby",
   }
 
-  s.add_dependency("faraday", "~> 0.13", "!= 0.16.0", "!= 0.16.1", "!= 0.16.2", "!= 0.17.1")
+  s.add_dependency("faraday", ">= 0.13", "< 2.0", "!= 0.16.0", "!= 0.16.1", "!= 0.16.2", "!= 0.17.1")
   s.add_dependency("net-http-persistent", "~> 3.0")
   s.add_dependency("ed25519", "~> 1")
 


### PR DESCRIPTION
This widens the permitted faraday version from `~> 0.13` (with some restrictions) to `>= 0.13, < 2.0`.  Tests pass locally using both Faraday `= 0.17.3` as well as using `~> 1.0`.

The only breaking change I found was related to restructuring the error hierarchy, which necessitated a single minor code change that appears to be backwards compatible.

With this change, the only dependency holding back ruby 3.0 support is `net-http-persistent`.

