### PR TITLE
Fix parameter wrapping in AvailablePhoneNumber.list to correctly hand…

### DIFF
--- a/lib/telnyx/api_operations/param_wrapper.rb
+++ b/lib/telnyx/api_operations/param_wrapper.rb
@@ -13,10 +13,13 @@ module Telnyx
 
       def wrap(method_name, wrapper)
         define_singleton_method(method_name) do |filters = {}, opts = {}|
-          return super(filters, opts) if filters.keys == [wrapper]
-
-          filters = { wrapper => filters }
-          super filters, opts
+          # If the only key is the wrapper key (e.g., 'filter'), pass it through as is
+          if filters.keys == [wrapper.to_sym] || filters.keys == [wrapper.to_s]
+            super(filters, opts)
+          else
+            # Otherwise, wrap the parameters in the wrapper key
+            super({ wrapper => filters }, opts)
+          end
         end
       end
     end

--- a/test/telnyx/param_wrapper_test.rb
+++ b/test/telnyx/param_wrapper_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Telnyx
+  class ParamWrapperTest < Test::Unit::TestCase
+    class TestResource < APIResource
+      extend Telnyx::APIOperations::List
+      extend Telnyx::APIOperations::ParamWrapper
+      wrap "list", "filter"
+      
+      OBJECT_NAME = "test_resource"
+      
+      # Override request to avoid actual API calls
+      def self.request(method, url, params = {}, opts = {})
+        # Store the parameters for verification
+        @@last_request_params = params
+        
+        # Return a mock response
+        resp = Struct.new(:data).new({ data: [] })
+        [resp, {}]
+      end
+      
+      # Method to retrieve the last request parameters
+      def self.last_request_params
+        @@last_request_params
+      end
+    end
+    
+    context ".list" do
+      should "correctly handle parameters when filter is explicitly provided" do
+        params = {
+          filter: {
+            country_code: "US",
+            limit: 1,
+            phone_number: { starts_with: "123" }
+          }
+        }
+        
+        TestResource.list(params)
+        
+        # Verify the parameters were passed correctly - note that keys may be strings or symbols
+        params = TestResource.last_request_params
+        
+        # Convert all keys to symbols for consistent comparison
+        params_with_symbol_keys = {}
+        params.each do |k, v|
+          params_with_symbol_keys[k.to_sym] = v
+        end
+        
+        assert_equal(
+          { filter: { country_code: "US", limit: 1, phone_number: { starts_with: "123" } } },
+          params_with_symbol_keys
+        )
+      end
+      
+      should "correctly wrap parameters when filter is not explicitly provided" do
+        params = {
+          country_code: "US",
+          limit: 1,
+          phone_number: { starts_with: "123" }
+        }
+        
+        TestResource.list(params)
+        
+        # Verify the parameters were wrapped correctly - note that keys may be strings or symbols
+        params = TestResource.last_request_params
+        
+        # Convert all keys to symbols for consistent comparison
+        params_with_symbol_keys = {}
+        params.each do |k, v|
+          params_with_symbol_keys[k.to_sym] = v
+        end
+        
+        assert_equal(
+          { filter: { country_code: "US", limit: 1, phone_number: { starts_with: "123" } } },
+          params_with_symbol_keys
+        )
+      end
+    end
+  end
+end

--- a/test/test_params.rb
+++ b/test/test_params.rb
@@ -1,0 +1,51 @@
+require 'bundler/setup'
+require 'telnyx'
+
+# Set a dummy API key
+Telnyx.api_key = 'TEST_API_KEY'
+
+# Monkey patch the request method to capture parameters without making API calls
+module Telnyx
+  module APIOperations
+    module Request
+      module ClassMethods
+        alias original_request request
+        
+        def request(method, url, params = {}, opts = {})
+          puts "Method: #{method}"
+          puts "URL: #{url}"
+          puts "Raw params: #{params.inspect}"
+          
+          if method.to_s.downcase.to_sym == :get
+            puts "URL-encoded params: #{Telnyx::Util.encode_parameters(params)}"
+          else
+            puts "JSON body: #{JSON.generate(params)}"
+          end
+          
+          # Return a mock response
+          mock_response = Struct.new(:data).new({data: []})
+          [mock_response, {}]
+        end
+      end
+    end
+  end
+end
+
+# Test with the parameters from the example
+puts "\n=== Testing with filter hash ==="
+response = Telnyx::AvailablePhoneNumber.list(
+  filter: {
+    country_code: "US",
+    limit: 1,
+    national_destination_code: "206",
+    phone_number: { starts_with: "4532888" }
+  }
+)
+
+puts "\n=== Testing with direct parameters ==="
+response = Telnyx::AvailablePhoneNumber.list(
+  country_code: "US",
+  limit: 1,
+  national_destination_code: "206",
+  phone_number: { starts_with: "4532888" }
+)


### PR DESCRIPTION
### PR Description

**Title: Fix parameter wrapping in AvailablePhoneNumber.list method**

**Ticket: [ENGDESK-39252](https://telnyx.atlassian.net/browse/ENGDESK-39252)**

**Description:**

This PR fixes an issue with the `AvailablePhoneNumber.list` method where filters like `limit` and `phone_number.starts_with` were not being correctly applied. The root cause was in the `ParamWrapper` module, which was incorrectly handling parameters when a `filter` parameter was explicitly provided, resulting in double-wrapped parameters (`filter[filter][...]` instead of `filter[...]`).

**Changes:**

1. **Modified `lib/telnyx/api_operations/param_wrapper.rb`**:
   - Updated the `wrap` method to correctly handle both string and symbol keys for the wrapper parameter
   - Ensured parameters are wrapped only once, regardless of whether the user passes a string or symbol key

2. **Added `test/telnyx/param_wrapper_test.rb`**:
   - Created unit tests to verify the parameter wrapping behavior
   - Tests both scenarios: when a filter parameter is explicitly provided and when parameters are provided directly

3. **Added `test_params.rb`**:
   - Added a test script to demonstrate the fix and show how parameters are processed
   - Useful for manual verification and debugging

**Testing:**
- Added unit tests that verify the parameter wrapping behavior
- Manually tested with various parameter combinations
- Verified that the fix resolves the issue with the `limit` and `phone_number.starts_with` filters

This fix ensures that API requests are correctly formatted, allowing filters to be properly applied when searching for available phone numbers.

[ENGDESK-39252]: https://telnyx.atlassian.net/browse/ENGDESK-39252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ