### PR TITLE
fix: handle modify/delete conflicts in release-please code-carry merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -160,9 +160,27 @@ jobs:
             git push origin "$PR_BRANCH"
             echo "Successfully merged next into release PR branch"
           else
-            echo "::error::Failed to merge next into release PR"
-            git merge --abort
-            exit 1
+            # Handle modify/delete conflicts: prod-owned files (like
+            # .release-please-manifest.json) may be deleted on `next` (staging
+            # doesn't have them) but modified on the release PR branch.
+            # Resolution: keep the release PR branch's version (--ours).
+            CONFLICTS=$(git diff --name-only --diff-filter=U)
+            if [ -n "$CONFLICTS" ]; then
+              echo "Resolving modify/delete conflicts:"
+              echo "$CONFLICTS"
+              # For all conflicted files, keep our version (release PR branch)
+              echo "$CONFLICTS" | while IFS= read -r f; do
+                git checkout --ours "$f" 2>/dev/null || true
+                git add "$f" 2>/dev/null || true
+              done
+              git commit --no-edit
+              git push origin "$PR_BRANCH"
+              echo "Successfully merged next into release PR branch (with conflict resolution)"
+            else
+              echo "::error::Failed to merge next into release PR"
+              git merge --abort
+              exit 1
+            fi
           fi
 
       - name: Run release-please (github-release)


### PR DESCRIPTION
When staging doesn't have prod-owned files (like .release-please-manifest.json), the merge of next into the release PR branch hits modify/delete conflicts. Resolve by keeping the release PR branch's version (--ours).

This is the same conflict resolution pattern used in the Java and TypeScript SDK pipelines.