### PR TITLE
fix: sync release-doctor + publish-gem to OIDC (no GEM_HOST_API_KEY)

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -1,13 +1,20 @@
-# workflow for re-running publishing to rubygems.org in case it fails for some reason
-# you can run this workflow by navigating to https://www.github.com/team-telnyx/telnyx-ruby/actions/workflows/publish-gem.yml
+# This workflow is triggered when a GitHub release is created.
+# It can also be run manually to re-publish to rubygems.org in case it failed for some reason.
+# You can run this workflow by navigating to https://www.github.com/team-telnyx/telnyx-ruby/actions/workflows/publish-gem.yml
 name: Publish Gem
 on:
   workflow_dispatch:
+
+  release:
+    types: [published]
 
 jobs:
   publish:
     name: publish
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -18,10 +25,9 @@ jobs:
       - run: |-
           bundle install
 
+      - name: Configure RubyGems Credentials
+        uses: rubygems/configure-rubygems-credentials@main
+
       - name: Publish to RubyGems.org
         run: |
           bash ./bin/publish-gem
-        env:
-          # `RUBYGEMS_HOST` is only required for private gem repositories, not https://rubygems.org
-          RUBYGEMS_HOST: ${{ secrets.TELNYX_RUBYGEMS_HOST || secrets.RUBYGEMS_HOST }}
-          GEM_HOST_API_KEY: ${{ secrets.TELNYX_GEM_HOST_API_KEY || secrets.GEM_HOST_API_KEY }}

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -18,6 +18,6 @@ jobs:
         run: |
           bash ./bin/check-release-environment
         env:
-          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          SDK_WRITE_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
           RUBYGEMS_HOST: ${{ secrets.TELNYX_RUBYGEMS_HOST || secrets.RUBYGEMS_HOST }}
           GEM_HOST_API_KEY: ${{ secrets.TELNYX_GEM_HOST_API_KEY || secrets.GEM_HOST_API_KEY }}

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -17,7 +17,3 @@ jobs:
       - name: Check release environment
         run: |
           bash ./bin/check-release-environment
-        env:
-          SDK_WRITE_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
-          RUBYGEMS_HOST: ${{ secrets.TELNYX_RUBYGEMS_HOST || secrets.RUBYGEMS_HOST }}
-          GEM_HOST_API_KEY: ${{ secrets.TELNYX_GEM_HOST_API_KEY || secrets.GEM_HOST_API_KEY }}

--- a/bin/check-release-environment
+++ b/bin/check-release-environment
@@ -2,8 +2,8 @@
 
 errors=()
 
-if [ -z "${RELEASE_PLEASE_TOKEN}" ]; then
-  errors+=("The RELEASE_PLEASE_TOKEN secret has not been set. Create a fine-grained GitHub PAT and add it as a repository secret.")
+if [ -z "${SDK_WRITE_TOKEN}" ]; then
+  errors+=("The SDK_WRITE_TOKEN secret has not been set. This is the GitHub PAT used by release-please and promote-to-prod workflows.")
 fi
 
 if [ -z "${GEM_HOST_API_KEY}" ]; then

--- a/bin/check-release-environment
+++ b/bin/check-release-environment
@@ -1,25 +1,6 @@
 #!/usr/bin/env bash
 
-errors=()
-
-if [ -z "${SDK_WRITE_TOKEN}" ]; then
-  errors+=("The SDK_WRITE_TOKEN secret has not been set. This is the GitHub PAT used by release-please and promote-to-prod workflows.")
-fi
-
-if [ -z "${GEM_HOST_API_KEY}" ]; then
-  errors+=("The GEM_HOST_API_KEY secret has not been set. Please set it in either this repository's secrets or your organization secrets")
-fi
-
-lenErrors=${#errors[@]}
-
-if [[ lenErrors -gt 0 ]]; then
-  echo -e "Found the following errors in the release environment:\n"
-
-  for error in "${errors[@]}"; do
-    echo -e "- $error\n"
-  done
-
-  exit 1
-fi
+# Ruby SDK now uses OIDC for RubyGems publishing via rubygems/configure-rubygems-credentials@main
+# No secret checks needed - OIDC authentication is handled in the publish workflow
 
 echo "The environment is ready to push releases!"


### PR DESCRIPTION
## Problem

The `next` branch had stale Stainless-era versions of 3 files, causing `release doctor` to fail on every PR:

1. `bin/check-release-environment` — checked `RELEASE_PLEASE_TOKEN` (never set, never used)
2. `release-doctor.yml` — passed `RELEASE_PLEASE_TOKEN` + `GEM_HOST_API_KEY` as env vars
3. `publish-gem.yml` — used `GEM_HOST_API_KEY` (token-based, old way)

## Reality (already on `master`)

- **RubyGems publishing uses OIDC** via `rubygems/configure-rubygems-credentials@main` — no stored tokens
- **release-please uses `SDK_WRITE_TOKEN`** — not `RELEASE_PLEASE_TOKEN`
- Gems publishing fine (v5.131.0 published Jun 18 ✅)

## Fix

Synced from `master`:
- `bin/check-release-environment` → no-op (OIDC, no secret checks needed)
- `release-doctor.yml` → removed all secret env vars
- `publish-gem.yml` → OIDC with `permissions: id-token: write`, triggers on `release: [published]`

`SDK_WRITE_TOKEN` is the only secret still in use (checkout + release-please CLI + gh CLI).