### PR TITLE
fix: restore release-please-config.json

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,66 @@
+{
+  "packages": {
+    ".": {}
+  },
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-v-in-tag": true,
+  "include-component-in-tag": false,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
+  "pull-request-header": "Automated Release PR",
+  "pull-request-title-pattern": "release: ${version}",
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "chore",
+      "section": "Chores"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation"
+    },
+    {
+      "type": "style",
+      "section": "Styles"
+    },
+    {
+      "type": "refactor",
+      "section": "Refactors"
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "section": "Build System"
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": true
+    }
+  ],
+  "release-type": "ruby",
+  "version-file": "lib/telnyx/version.rb",
+  "extra-files": [
+    "README.md",
+    "telnyx.gemspec"
+  ]
+}


### PR DESCRIPTION
## Problem\n\nRelease-please failed with `ConfigurationError: Missing required manifest config: release-please-config.json`.\n\n## Root Cause\n\nPR #271 added this config to master. But when release PR #275 was squash-merged, the file was deleted because:\n1. The release PR branch was built from `next`\n2. `next` never had the config file\n3. Promote-to-prod restores `release-please-config.json` from `next` (with `2>/dev/null || true`), so the missing file is silently ignored\n4. The squash merge carried this deletion to master\n\n## Fix\n\n1. Restore `release-please-config.json` on master (this PR)\n2. Also push to `next` branch so future promote-to-prod runs restore it correctly\n\nAfter this merges, release-please will re-trigger and create the v5.147.0 tag.