### PR TITLE
fix: restore OIDC + release trigger in publish-gem.yml

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -1,13 +1,20 @@
-# workflow for re-running publishing to rubygems.org in case it fails for some reason
-# you can run this workflow by navigating to https://www.github.com/team-telnyx/telnyx-ruby/actions/workflows/publish-gem.yml
+# This workflow is triggered when a GitHub release is created.
+# It can also be run manually to re-publish to rubygems.org in case it failed for some reason.
+# You can run this workflow by navigating to https://www.github.com/team-telnyx/telnyx-ruby/actions/workflows/publish-gem.yml
 name: Publish Gem
 on:
   workflow_dispatch:
+
+  release:
+    types: [published]
 
 jobs:
   publish:
     name: publish
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -18,10 +25,9 @@ jobs:
       - run: |-
           bundle install
 
+      - name: Configure RubyGems Credentials
+        uses: rubygems/configure-rubygems-credentials@main
+
       - name: Publish to RubyGems.org
         run: |
           bash ./bin/publish-gem
-        env:
-          # `RUBYGEMS_HOST` is only required for private gem repositories, not https://rubygems.org
-          RUBYGEMS_HOST: ${{ secrets.TELNYX_RUBYGEMS_HOST || secrets.RUBYGEMS_HOST }}
-          GEM_HOST_API_KEY: ${{ secrets.TELNYX_GEM_HOST_API_KEY || secrets.GEM_HOST_API_KEY }}


### PR DESCRIPTION
## Problem\n\n`publish-gem.yml` was overwritten by PR #275's squash merge. The old version lost:\n- `release: types: [published]` trigger → publish doesn't auto-run on release\n- `permissions: id-token: write` → no OIDC\n- `rubygems/configure-rubygems-credentials@main` step → no OIDC credential setup\n- Fell back to `GEM_HOST_API_KEY` secret (which may not exist)\n\n## Root Cause\n\nPromote-to-prod restores `publish-gem.yml` from `next` branch. PR #275's commit message claimed to sync OIDC on next, but the restored version is the old token-based one.\n\n## Fix\n\n1. Restored OIDC version on `next` (so future promotes preserve it)\n2. This PR restores it on `master`\n\nAfter merge, manually trigger the publish workflow to push v5.147.0 to RubyGems.