### PR TITLE
fix: restore release-please-config.json deleted by release PR merge

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,66 @@
+{
+  "packages": {
+    ".": {}
+  },
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-v-in-tag": true,
+  "include-component-in-tag": false,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
+  "pull-request-header": "Automated Release PR",
+  "pull-request-title-pattern": "release: ${version}",
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "chore",
+      "section": "Chores"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation"
+    },
+    {
+      "type": "style",
+      "section": "Styles"
+    },
+    {
+      "type": "refactor",
+      "section": "Refactors"
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "section": "Build System"
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": true
+    }
+  ],
+  "release-type": "ruby",
+  "version-file": "lib/telnyx/version.rb",
+  "extra-files": [
+    "README.md",
+    "telnyx.gemspec"
+  ]
+}


### PR DESCRIPTION
## What

Restores `release-please-config.json` on `master` which was deleted when PR #281 merged.

## Why

The release PR carried a deletion from the `next` branch — staging doesn't have prod-owned files like `release-please-config.json`. When the PR merged to `master`, it wiped out the config file that `release-please` needs.

Result: the `github-release` step failed:
```
ConfigurationError: Missing required manifest config: release-please-config.json
```

No `v5.148.0` tag or GitHub release was created → `publish-gem.yml` never triggered → RubyGems stuck at v5.147.0.

## Fix

Restore the file from the commit before the merge (`d0fb7f1~1`). After merge, push to `master` will re-trigger `release-please` which sees 5.148.0 in the manifest with no existing release → creates tag + release → `publish-gem.yml` fires → publishes to RubyGems.

## Root cause (recurring)

The promote-to-prod workflow syncs staging to `next`, but staging doesn't carry prod-owned files. The release PR merge carries those deletions forward. This is the same issue as PR #280. The fix is to add `release-please-config.json` to the prod-owned restore list in the promote-to-prod workflow on staging.