### PR TITLE
fix: restore release:published trigger + OIDC in publish-gem.yml

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -1,13 +1,20 @@
-# workflow for re-running publishing to rubygems.org in case it fails for some reason
-# you can run this workflow by navigating to https://www.github.com/team-telnyx/telnyx-ruby/actions/workflows/publish-gem.yml
+# This workflow is triggered when a GitHub release is created.
+# It can also be run manually to re-publish to rubygems.org in case it failed for some reason.
+# You can run this workflow by navigating to https://www.github.com/team-telnyx/telnyx-ruby/actions/workflows/publish-gem.yml
 name: Publish Gem
 on:
   workflow_dispatch:
+
+  release:
+    types: [published]
 
 jobs:
   publish:
     name: publish
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -18,10 +25,9 @@ jobs:
       - run: |-
           bundle install
 
+      - name: Configure RubyGems Credentials
+        uses: rubygems/configure-rubygems-credentials@main
+
       - name: Publish to RubyGems.org
         run: |
           bash ./bin/publish-gem
-        env:
-          # `RUBYGEMS_HOST` is only required for private gem repositories, not https://rubygems.org
-          RUBYGEMS_HOST: ${{ secrets.TELNYX_RUBYGEMS_HOST || secrets.RUBYGEMS_HOST }}
-          GEM_HOST_API_KEY: ${{ secrets.TELNYX_GEM_HOST_API_KEY || secrets.GEM_HOST_API_KEY }}


### PR DESCRIPTION
## What

Restore the `release: published` trigger and OIDC credentials in `publish-gem.yml` — same changes as PR #282, which were reverted by the PR #281 merge.

## Why

PR #282 added:
- `release: published` trigger (auto-publish on GitHub release)
- `permissions: id-token: write` (OIDC auth)
- `rubygems/configure-rubygems-credentials` action (OIDC instead of API key)

PR #281 (release: 5.148.0) merged to master and carried the staging version of `publish-gem.yml` (which only has `workflow_dispatch`), reverting PR #282's fix.

Result: v5.148.0 tag was created (after PR #283 restored release-please-config.json), but the release event didn't trigger `publish-gem.yml` — no RubyGems publish.

## Fix

Same as PR #282. This is the 2nd time this has been reverted by a release PR merge.

## Root cause fix (staging)

PR #120 on telnyx-ruby-staging moves ALL prod-owned file restores from `next` to `master`, so manual fixes on master survive future release PR merges.