### PR TITLE
fix: pin rubygems/configure-rubygems-credentials to SHA

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -26,7 +26,7 @@ jobs:
           bundle install
 
       - name: Configure RubyGems Credentials
-        uses: rubygems/configure-rubygems-credentials@main
+        uses: rubygems/configure-rubygems-credentials@6861877652452567c1a007a50badad3d316fc9ba
 
       - name: Publish to RubyGems.org
         run: |


### PR DESCRIPTION
## What

Pin `rubygems/configure-rubygems-credentials` to SHA `6861877` for consistency with other pinned actions in the workflow.

PR #284 was merged before the SHA pin commit landed, so master currently has `@main`.

## Why

All other actions in publish-gem.yml are pinned to SHAs (checkout, setup-ruby). The credentials action should follow the same pattern for security and reproducibility.