### PR TITLE
fix: release-doctor.yml — pass SDK_WRITE_TOKEN instead of RELEASE_PLEASE_TOKEN

### DIFF
--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -18,6 +18,6 @@ jobs:
         run: |
           bash ./bin/check-release-environment
         env:
-          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          SDK_WRITE_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
           RUBYGEMS_HOST: ${{ secrets.TELNYX_RUBYGEMS_HOST || secrets.RUBYGEMS_HOST }}
           GEM_HOST_API_KEY: ${{ secrets.TELNYX_GEM_HOST_API_KEY || secrets.GEM_HOST_API_KEY }}


### PR DESCRIPTION
Same fix as Python/Node/PHP: `release-doctor.yml` passes `RELEASE_PLEASE_TOKEN` (which doesn't exist as a secret) to `check-release-environment`. Updated to use `SDK_WRITE_TOKEN`.