### PR TITLE
fix: replace git merge with tree replacement in release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -107,7 +107,7 @@ jobs:
             echo "prs_created=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Merge next code into release PR
+      - name: Sync next code into release PR (tree replacement, not merge)
         if: github.ref == 'refs/heads/next'
         env:
           GH_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
@@ -115,17 +115,18 @@ jobs:
           PR_NUM: ${{ steps.release-pr.outputs.pr_number }}
         run: |
           # release-please creates a PR with only version bumps (CHANGELOG,
-          # version.rb, README, etc). The actual SDK code changes are
-          # on `next` but NOT included in the release PR. This step merges
-          # `next` into the release PR branch so the PR carries both code
-          # and version bumps to master.
+          # version.rb, README, gemspec, CHANGELOG.md, .release-please-manifest.json).
+          # The actual SDK code changes are on `next` but NOT included in the
+          # release PR. This step syncs `next` code into the release PR branch.
           #
-          # Without this, master gets version bumps only — the published
-          # gem has the new version number but old code.
+          # CRITICAL: We use tree replacement (checkout + restore version files)
+          # instead of git merge. A 3-way merge produces duplicate method
+          # implementations when staging and prod have different method ordering
+          # (git sees them as non-conflicting additions and keeps both copies).
+          # Tree replacement avoids this entirely — the code tree comes from
+          # `next` as-is, and only the version-bump files from release-please
+          # are preserved on top.
 
-          # Use the PR number from the release-please step directly (avoids
-          # GitHub API eventual-consistency race where gh pr list doesn't see
-          # a PR that was created milliseconds ago).
           PR_BRANCH=""
           if [ -n "$PR_NUM" ]; then
             sleep 3  # brief propagation delay
@@ -143,7 +144,7 @@ jobs:
           fi
 
           if [ -z "$PR_BRANCH" ]; then
-            echo "::warning::No open release PR found after retries, skipping merge"
+            echo "::warning::No open release PR found after retries, skipping sync"
             exit 0
           fi
 
@@ -154,36 +155,37 @@ jobs:
           git fetch origin "$PR_BRANCH" next
           git checkout -B "$PR_BRANCH" "origin/$PR_BRANCH"
 
-          # -X ours: on conflicts, prefer the release-please branch's version
-          # bumps (canonical version + changelog). Non-conflicting code changes
-          # from next are included normally.
-          if git merge origin/next --no-edit -X ours; then
-            git push origin "$PR_BRANCH"
-            echo "Successfully merged next into release PR branch"
-          else
-            # Handle modify/delete conflicts: prod-owned files (like
-            # .release-please-manifest.json) may be deleted on `next` (staging
-            # doesn't have them) but modified on the release PR branch.
-            # Resolution: keep the release PR branch's version (--ours).
-            CONFLICTS=$(git diff --name-only --diff-filter=U)
-            if [ -n "$CONFLICTS" ]; then
-              echo "Resolving modify/delete conflicts:"
-              echo "$CONFLICTS"
-              # For all conflicted files, keep our version (release PR branch)
-              echo "$CONFLICTS" | while IFS= read -r f; do
-                git checkout --ours "$f" 2>/dev/null || true
-                git add "$f" 2>/dev/null || true
-              done
-              git commit --no-edit
-              git push origin "$PR_BRANCH"
-              echo "Successfully merged next into release PR branch (with conflict resolution)"
-            else
-              echo "::error::Failed to merge next into release PR"
-              git merge --abort
-              exit 1
+          # Save version-bump files from the release PR branch (release-please output)
+          STASH_DIR=$(mktemp -d)
+          for f in CHANGELOG.md lib/telnyx/version.rb README.md telnyx.gemspec .release-please-manifest.json; do
+            if [ -f "$f" ]; then
+              mkdir -p "$STASH_DIR/$(dirname "$f")"
+              cp "$f" "$STASH_DIR/$f"
             fi
-          fi
+          done
 
+          # Replace entire working tree from next (exact tree, no merge)
+          git checkout origin/next -- .
+          git add -A
+
+          # Restore version-bump files from the release PR branch
+          for f in CHANGELOG.md lib/telnyx/version.rb README.md telnyx.gemspec .release-please-manifest.json; do
+            if [ -f "$STASH_DIR/$f" ]; then
+              mkdir -p "$(dirname "$f")"
+              cp "$STASH_DIR/$f" "$f"
+              git add "$f"
+            fi
+          done
+          rm -rf "$STASH_DIR"
+
+          # Commit if there are changes
+          if git diff --cached --quiet; then
+            echo "No changes after syncing next code"
+          else
+            git commit -m "chore: sync code from next into release PR"
+            git push origin "$PR_BRANCH"
+            echo "Successfully synced next code into release PR branch (tree replacement)"
+          fi
       - name: Run release-please (github-release)
         if: github.ref == 'refs/heads/master'
         run: |


### PR DESCRIPTION
## Root-Cause Fix: Replace git merge with tree replacement in release-please.yml

### Problem
The `git merge origin/next -X ours/theirs` step in the release-please workflow produces **duplicate method implementations** when staging (`next`) and prod have different method ordering. Git sees reordered methods as non-conflicting additions and keeps both copies, resulting in duplicate code on prod.

### Solution
Replace the 3-way merge with **tree replacement**:
1. Save version-bump files from the release PR branch (release-please output)
2. Replace the entire working tree from `next` (`git checkout origin/next -- .`)
3. Restore the version-bump files on top
4. Commit and push

This eliminates the merge entirely — the code tree comes from `next` as-is, with only version-bump files preserved from release-please.

### Version files preserved
- `CHANGELOG.md lib/telnyx/version.rb README.md telnyx.gemspec .release-please-manifest.json`

### Reference
Same fix applied to telnyx-node in PR #466 (https://github.com/team-telnyx/telnyx-node/pull/466)