### PR TITLE
fix: add git clean -fdx to tree replacement step in release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -165,7 +165,11 @@ jobs:
           done
 
           # Replace entire working tree from next (exact tree, no merge)
+          # git rm handles deletions (files removed in next but still in this branch)
+          # git clean removes untracked files (node_modules created by npx release-please)
+          git rm -rf . 2>/dev/null || true
           git checkout origin/next -- .
+          git clean -fdx
           git add -A
 
           # Restore version-bump files from the release PR branch


### PR DESCRIPTION
## Fix: Remove untracked `node_modules/` from tree replacement step

### Problem
The tree replacement step in release-please.yml runs `git add -A` after `git checkout origin/next -- .`. But `npx release-please` (which runs earlier in the same workflow) creates `node_modules/` in the GitHub Actions workspace. `git add -A` picks up these untracked files and commits them to the release PR.

Observed on telnyx-python PR #368: **2,566 files / 1.4M additions**, of which 298 were `node_modules/` files (typescript, @octokit, etc.) from `npx release-please`. The actual SDK changes were only 2 files.

### Fix
Replace:
```bash
git checkout origin/next -- .
git add -A
```
With:
```bash
git rm -rf . 2>/dev/null || true   # Remove all tracked files (handles deletions)
git checkout origin/next -- .      # Checkout all files from next
git clean -fdx                     # Remove untracked files (node_modules, etc.)
git add -A                         # Stage clean tree
```

- `git rm -rf .` ensures files deleted in `next` are properly removed (git checkout only updates/adds, doesn't delete)
- `git clean -fdx` removes untracked files like `node_modules/` created by `npx release-please`
