### PR TITLE
ci: auto-merge release PRs with --squash (repo forbids merge commits)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -247,11 +247,11 @@ jobs:
           PR_NUM: ${{ steps.release-pr.outputs.pr_number }}
         run: |
           if [ -n "$PR_NUM" ]; then
-            gh pr merge "$PR_NUM" --auto --merge --repo "$REPO" 2>/dev/null || echo "Auto-merge already enabled or PR #$PR_NUM not mergeable"
+            gh pr merge "$PR_NUM" --auto --squash --repo "$REPO" 2>/dev/null || echo "Auto-merge already enabled or PR #$PR_NUM not mergeable"
           fi
           sleep 3
           # Fallback: enable auto-merge on any open release PRs
           prs=$(gh pr list --repo "$REPO" --state open --label "autorelease: pending" --json number --jq '.[].number')
           for pr in $prs; do
-            gh pr merge "$pr" --auto --merge --repo "$REPO" 2>/dev/null || true
+            gh pr merge "$pr" --auto --squash --repo "$REPO" 2>/dev/null || true
           done


### PR DESCRIPTION
The 'Enable auto-merge on release PRs' step uses `gh pr merge --auto --merge`, but this repo only allows squash merges — so arming auto-merge fails on every release ('Merge commits are not allowed on this repository'), silently swallowed by `|| true`, and every release PR needs a manual merge. Switch both merge calls to `--squash`. Verified safe: telnyx-cli v0.20.0 released cleanly via squash today (label survives, release-please tags, publish fires).