### PR TITLE
fix: scan next commits when creating release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -103,13 +103,12 @@ jobs:
           # still created against master via the API.
           git branch -f master HEAD 2>/dev/null || true
           git update-ref refs/remotes/origin/master HEAD
-          # --local mode clones from --repo-url — a FRESH GitHub clone whose
-          # refs ignore the repoint above (it only rewrites this workspace), so
-          # the scan saw 0 commits on a quiet master and silently skipped the
-          # release PR (2026-07-09). Rewrite the URL to this workspace so the
-          # CLI clones the repointed refs; API PR-creation still parses
-          # owner/repo from the URL string.
-          git config --global url."file://${GITHUB_WORKSPACE}".insteadOf "${{ github.repositoryUrl }}"
+          # --local mode normalizes --repo-url to HTTPS before cloning. Rewrite
+          # that normalized URL to this workspace so the clone sees the
+          # repointed target branch above instead of the quiet remote branch.
+          # Keep --repo-url unchanged so API PR creation still parses owner/repo.
+          git config --global protocol.file.allow always
+          git config --global url."file://${GITHUB_WORKSPACE}".insteadOf "https://github.com/${{ github.repository }}.git"
 
           OUTPUT=$(npx release-please "${ARGS[@]}" 2>&1) || true
           echo "$OUTPUT"


### PR DESCRIPTION
## Summary
- rewrite release-please's normalized HTTPS clone URL to the prepared Actions workspace
- allow `--local` to scan the promoted `next` commits instead of the quiet production `master` branch
- preserve the existing API repository URL used to create the release PR

## Root cause
The workflow repointed the local `master` ref to `next`, then configured an `insteadOf` rule for the original `git://` repository URL. release-please normalizes that URL to HTTPS before invoking `git clone`, so the rule never matched. It cloned GitHub again, found 0 commits on `master`, and silently skipped the release PR despite `--release-as 5.158.0`.

Failed proof: https://github.com/team-telnyx/telnyx-ruby/actions/runs/29791139626

## Expected behavior
After this merges, the next staging promotion updates production `next`. release-please's local clone sees the promoted commits and creates a fresh release PR when none is open; if one is already open, it updates it.

## Verification
- `actionlint -ignore SC2034 .github/workflows/release-please.yml`
- `git diff --check`
- verified the HTTPS `insteadOf` rule resolves `master` to the locally repointed `next` SHA
- diff is limited to `.github/workflows/release-please.yml`
