### PR TITLE
fix(release): support fresh-runner release synchronization

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -211,7 +211,7 @@ jobs:
 
           BASE_BRANCH="${{ github.event.repository.default_branch }}"
           git fetch origin "$PR_BRANCH" next "$BASE_BRANCH:refs/remotes/origin/release-base"
-          git checkout -B "$PR_BRANCH" "origin/$PR_BRANCH"
+          git checkout -f -B "$PR_BRANCH" "origin/$PR_BRANCH"
 
           # Save version-bump files from the release PR branch (release-please output)
           STASH_DIR=$(mktemp -d)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -102,6 +102,11 @@ jobs:
           BASE_BRANCH="${{ github.event.repository.default_branch }}"
           git fetch origin "$BASE_BRANCH:refs/remotes/origin/release-base" next
           RELEASE_BASE=$(git rev-parse refs/remotes/origin/release-base)
+
+          # git commit-tree needs an explicit identity on fresh Actions runners.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           RELEASE_FILES=("CHANGELOG.md" "lib/telnyx/version.rb" "README.md" "telnyx.gemspec" ".release-please-manifest.json")
           git restore --source=refs/remotes/origin/release-base --staged --worktree -- "${RELEASE_FILES[@]}"
           SCAN_TREE=$(git write-tree)
@@ -203,8 +208,6 @@ jobs:
           fi
 
           echo "Found release PR branch: $PR_BRANCH"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
 
           BASE_BRANCH="${{ github.event.repository.default_branch }}"
           git fetch origin "$PR_BRANCH" next "$BASE_BRANCH:refs/remotes/origin/release-base"


### PR DESCRIPTION
## Summary\n- configure the Actions bot Git identity before creating the synthetic clean-history commit\n- force-discard temporary caller-worktree changes left by `release-please --local` before checking out the authoritative remote release branch\n\n## Root cause\nFresh runners initially failed because `git commit-tree` had no author identity. After that was fixed, `release-please --local` left generated changelog/version files dirty, causing the later normal branch checkout to abort.\n\n## Validation\n- isolated no-global-Git-config regression test for `git commit-tree`\n- `git diff --check`\n- `actionlint -ignore SC2034 .github/workflows/release-please.yml`\n