### PR TITLE
ci: use large runner for Ruby Steep

### DIFF
--- a/.github/scripts/run_steep_shard.py
+++ b/.github/scripts/run_steep_shard.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Run one deterministic, size-balanced shard of Ruby and RBS Steep inputs."""
+
+import argparse
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+
+def partition_steep_files(root: Path, shard_count: int) -> List[List[Path]]:
+    if shard_count < 1:
+        raise ValueError("shard count must be positive")
+
+    root = root.resolve()
+    files = []
+    for directory, pattern in (("lib", "*.rb"), ("sig", "*.rbs")):
+        input_root = (root / directory).resolve()
+        for path in (root / directory).rglob(pattern):
+            if not path.is_file():
+                continue
+            resolved = path.resolve()
+            try:
+                resolved.relative_to(input_root)
+            except ValueError as error:
+                raise ValueError(f"Steep input escapes {directory}/: {path}") from error
+            files.append(resolved)
+
+    if not files:
+        raise ValueError("no Steep input files found under lib/ or sig/")
+    if shard_count > len(files):
+        raise ValueError("shard count exceeds Steep input file count")
+
+    shards: List[List[Path]] = [[] for _ in range(shard_count)]
+    totals = [0] * shard_count
+    ordered = sorted(files, key=lambda path: (-path.stat().st_size, path.as_posix()))
+    for path in ordered:
+        index = min(range(shard_count), key=lambda item: (totals[item], item))
+        shards[index].append(path)
+        totals[index] += path.stat().st_size
+
+    for shard in shards:
+        shard.sort(key=lambda path: path.as_posix())
+    return shards
+
+
+def command_for_shard(
+    root: Path, shard_index: int, shard_count: int, jobs: int
+) -> List[str]:
+    if not 0 <= shard_index < shard_count:
+        raise ValueError("shard index must be within the shard count")
+    if jobs < 1:
+        raise ValueError("jobs must be positive")
+
+    root = root.resolve()
+    shards = partition_steep_files(root, shard_count)
+    selected = [path.relative_to(root).as_posix() for path in shards[shard_index]]
+    return ["bundle", "exec", "steep", "check", f"--jobs={jobs}", *selected]
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--shard-index", type=int, required=True)
+    parser.add_argument("--shard-count", type=int, required=True)
+    parser.add_argument("--jobs", type=int, default=2)
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    root = Path.cwd().resolve()
+    command = command_for_shard(
+        root,
+        shard_index=args.shard_index,
+        shard_count=args.shard_count,
+        jobs=args.jobs,
+    )
+    selected = command[5:]
+    total_bytes = sum((root / path).stat().st_size for path in selected)
+    ruby_count = sum(path.endswith(".rb") for path in selected)
+    rbs_count = sum(path.endswith(".rbs") for path in selected)
+    print(
+        f"Running Steep shard {args.shard_index + 1}/{args.shard_count}: "
+        f"{ruby_count} Ruby files, {rbs_count} RBS files, "
+        f"{total_bytes} input bytes",
+        flush=True,
+    )
+    subprocess.run(command, cwd=root, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_ci_runner_policy.py
+++ b/.github/scripts/test_ci_runner_policy.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+import unittest
+from pathlib import Path
+
+WORKFLOW = Path(__file__).parents[1] / "workflows" / "ci.yml"
+
+
+def job_block(text: str, name: str, next_name: str) -> str:
+    start = f"  {name}:\n"
+    end = f"\n  {next_name}:\n"
+    if text.count(start) != 1 or text.count(end) != 1:
+        raise AssertionError(f"unable to isolate {name} job")
+    return text.split(start, 1)[1].split(end, 1)[0]
+
+
+class CiRunnerPolicyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.workflow = WORKFLOW.read_text()
+
+    def test_production_steep_shards_use_github_hosted_runners(self) -> None:
+        shards = job_block(self.workflow, "lint-steep-shards", "lint-steep-staging")
+        self.assertIn("runs-on: ubuntu-latest", shards)
+        self.assertNotIn("telnyx-2xlarge", shards)
+        self.assertIn("matrix:", shards)
+        self.assertIn("shard: [0, 1, 2, 3]", shards)
+        self.assertIn("github.repository == 'team-telnyx/telnyx-ruby'", shards)
+        self.assertIn("run_steep_shard.py", shards)
+
+    def test_staging_retains_internal_large_runner(self) -> None:
+        staging = job_block(self.workflow, "lint-steep-staging", "lint-steep")
+        self.assertIn("runs-on: telnyx-2xlarge", staging)
+        self.assertIn("github.repository == 'team-telnyx/telnyx-ruby-staging'", staging)
+        self.assertIn("bundle exec steep check --jobs=4", staging)
+
+    def test_aggregator_preserves_required_check_name_and_fails_closed(self) -> None:
+        steep = job_block(self.workflow, "lint-steep", "lint-sorbet")
+        self.assertIn("name: lint (steep)", steep)
+        self.assertIn("runs-on: ubuntu-latest", steep)
+        self.assertIn("if: always()", steep)
+        self.assertIn("needs:", steep)
+        self.assertIn("lint-steep-shards", steep)
+        self.assertIn("lint-steep-staging", steep)
+        self.assertNotIn("lint-steep-signatures", steep)
+        self.assertIn("exit 1", steep)
+
+    def test_existing_rubocop_check_runs_policy_tests(self) -> None:
+        rubocop = job_block(self.workflow, "lint-rubocop", "lint-steep-shards")
+        self.assertIn("python3 .github/scripts/test_ci_runner_policy.py", rubocop)
+        self.assertIn("python3 .github/scripts/test_run_steep_shard.py", rubocop)
+        self.assertIn("name: lint (rubocop)", rubocop)
+
+    def test_serial_production_signature_job_is_removed(self) -> None:
+        self.assertNotIn("  lint-steep-signatures:\n", self.workflow)
+        self.assertNotIn("--no-type-check --validate=project", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_run_steep_shard.py
+++ b/.github/scripts/test_run_steep_shard.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("run_steep_shard.py")
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("run_steep_shard", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise AssertionError("unable to load shard helper")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RunSteepShardTest(unittest.TestCase):
+    def test_shards_are_deterministic_disjoint_and_complete(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            files = []
+            for subdir, suffix, sizes in [
+                ("lib", ".rb", [80, 30, 10, 3]),
+                ("sig", ".rbs", [50, 20, 5]),
+            ]:
+                for index, size in enumerate(sizes):
+                    path = root / subdir / f"file_{index}{suffix}"
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_bytes(b"x" * size)
+                    files.append(path)
+            (root / "lib" / "ignored.txt").write_text("not a Steep input")
+
+            first = module.partition_steep_files(root, shard_count=3)
+            second = module.partition_steep_files(root, shard_count=3)
+
+            self.assertEqual(first, second)
+            flattened = [path for shard in first for path in shard]
+            self.assertCountEqual(flattened, [path.resolve() for path in files])
+            self.assertEqual(len(flattened), len(set(flattened)))
+
+    def test_greedy_partition_balances_input_bytes(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for index, size in enumerate([100, 80, 60, 40]):
+                path = root / "lib" / f"file_{index}.rb"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"x" * size)
+            for index, size in enumerate([90, 70, 50, 30]):
+                path = root / "sig" / f"file_{index}.rbs"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"x" * size)
+
+            shards = module.partition_steep_files(root, shard_count=4)
+            totals = [sum(path.stat().st_size for path in shard) for shard in shards]
+            self.assertLessEqual(max(totals) - min(totals), 30)
+
+    def test_rejects_invalid_shard_arguments_and_empty_inputs(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "lib").mkdir()
+            (root / "sig").mkdir()
+            with self.assertRaisesRegex(ValueError, "no Steep input files"):
+                module.partition_steep_files(root, shard_count=2)
+            with self.assertRaisesRegex(ValueError, "shard count"):
+                module.partition_steep_files(root, shard_count=0)
+            with self.assertRaisesRegex(ValueError, "shard index"):
+                module.command_for_shard(root, shard_index=2, shard_count=2, jobs=2)
+
+    def test_command_checks_selected_ruby_and_rbs_files(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for index, size in enumerate([40, 20]):
+                path = root / "lib" / f"file_{index}.rb"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"x" * size)
+            for index, size in enumerate([30, 10]):
+                path = root / "sig" / f"file_{index}.rbs"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"x" * size)
+
+            commands = [
+                module.command_for_shard(root, shard_index=index, shard_count=2, jobs=2)
+                for index in range(2)
+            ]
+            for command in commands:
+                self.assertEqual(
+                    command[:5],
+                    ["bundle", "exec", "steep", "check", "--jobs=2"],
+                )
+                self.assertNotIn("--validate=skip", command)
+                self.assertTrue(command[5:])
+            selected = [path for command in commands for path in command[5:]]
+            self.assertTrue(any(path.startswith("lib/") for path in selected))
+            self.assertTrue(any(path.startswith("sig/") for path in selected))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Validate CI runner policy
+        run: |-
+          python3 .github/scripts/test_ci_runner_policy.py
+          python3 .github/scripts/test_run_steep_shard.py
       - name: Set up Ruby
         uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
@@ -31,11 +35,34 @@ jobs:
       - name: Run rubocop
         run: bundle exec rake lint:rubocop
 
-  lint-steep:
+  lint-steep-shards:
     timeout-minutes: 60
-    name: lint (steep)
-    runs-on: ${{ github.repository == 'team-telnyx/telnyx-ruby-staging' && 'telnyx-2xlarge' || 'ubuntu-latest' }}
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    name: lint (steep shard ${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    if: github.repository == 'team-telnyx/telnyx-ruby' && (github.event_name == 'push' || github.event_name == 'pull_request')
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
+        with:
+          bundler-cache: false
+      - run: bundle install
+      - name: Run Steep shard
+        run: |-
+          python3 .github/scripts/run_steep_shard.py \
+            --shard-index "${{ matrix.shard }}" \
+            --shard-count 4 \
+            --jobs 2
+
+  lint-steep-staging:
+    timeout-minutes: 60
+    name: lint (steep staging)
+    runs-on: telnyx-2xlarge
+    if: github.repository == 'team-telnyx/telnyx-ruby-staging' && (github.event_name == 'push' || github.event_name == 'pull_request')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Fix tool cache permissions
@@ -44,10 +71,34 @@ jobs:
         uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           bundler-cache: false
-      - run: |-
-          bundle install
+      - run: bundle install
       - name: Run steep
         run: bundle exec steep check --jobs=4
+
+  lint-steep:
+    timeout-minutes: 5
+    name: lint (steep)
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - lint-steep-shards
+      - lint-steep-staging
+    steps:
+      - name: Verify repository-specific Steep checks
+        env:
+          SHARDS_RESULT: ${{ needs.lint-steep-shards.result }}
+          STAGING_RESULT: ${{ needs.lint-steep-staging.result }}
+        run: |-
+          if [[ "${{ github.repository }}" == "team-telnyx/telnyx-ruby" ]]; then
+            [[ "$SHARDS_RESULT" == "success" ]] || exit 1
+            [[ "$STAGING_RESULT" == "skipped" ]] || exit 1
+          elif [[ "${{ github.repository }}" == "team-telnyx/telnyx-ruby-staging" ]]; then
+            [[ "$SHARDS_RESULT" == "skipped" ]] || exit 1
+            [[ "$STAGING_RESULT" == "success" ]] || exit 1
+          else
+            echo "Unsupported repository for Steep CI: ${{ github.repository }}"
+            exit 1
+          fi
 
   lint-sorbet:
     timeout-minutes: 20


### PR DESCRIPTION
## Summary
- keep public production CI entirely on GitHub-hosted `ubuntu-latest` runners
- split production Ruby and RBS type checking into four deterministic, size-balanced Steep shards
- fail closed through the existing required `lint (steep)` aggregate context
- retain the existing single `telnyx-2xlarge` Steep job for the private staging repository

## Hosted result
Exact validated head: `113d265867d6e4eac4c3310e739ad15ce2fd9284`

Equivalent generated-tree comparison on 2026-08-15:
- push run `31900951676`: 49m20s → 18m30s (**30m50s / 62.5% faster**)
- pull-request run `31900954193`: 50m39s → 18m13s (**32m26s / 64.0% faster**)
- all shard, aggregate, test, lint, protected-path, and CodeQL checks passed

The first implementation attempted `telnyx-2xlarge` in production, but both jobs remained unassigned and were cancelled after about 11 minutes. Production does not have access to that internal runner group, and access should not be granted to a public repository.

## Correctness and safety
- all 3,192 `lib/**/*.rb` and 3,178 `sig/**/*.rbs` files are assigned exactly once
- shard input-byte totals: 3,809,290 / 3,809,244 / 3,809,276 / 3,809,296
- each shard passes its selected Ruby and RBS paths directly to Steep 1.10, preserving source checking and signature validation
- the aggregator rejects failed, cancelled, or unexpectedly skipped repository-specific jobs
- required ruleset context remains `lint (steep)`
- no branch-protection context or type-check coverage is removed

## Local validation
- `python3 .github/scripts/test_ci_runner_policy.py -v`
- `python3 .github/scripts/test_run_steep_shard.py -v`
- `python3 -m py_compile .github/scripts/*.py`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

Linear: DOT-2057
