### PR TITLE
ci: install isolated Steep worker control plane

### DIFF
--- a/.github/scripts/run_steep_shard.py
+++ b/.github/scripts/run_steep_shard.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Run one deterministic, size-balanced shard of Ruby and RBS Steep inputs."""
+
+import argparse
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+
+def partition_steep_files(root: Path, shard_count: int) -> List[List[Path]]:
+    if shard_count < 1:
+        raise ValueError("shard count must be positive")
+
+    root = root.resolve()
+    files = []
+    for directory, pattern in (("lib", "*.rb"), ("sig", "*.rbs")):
+        input_root = (root / directory).resolve()
+        for path in (root / directory).rglob(pattern):
+            if not path.is_file():
+                continue
+            resolved = path.resolve()
+            try:
+                resolved.relative_to(input_root)
+            except ValueError as error:
+                raise ValueError(f"Steep input escapes {directory}/: {path}") from error
+            files.append(resolved)
+
+    if not files:
+        raise ValueError("no Steep input files found under lib/ or sig/")
+    if shard_count > len(files):
+        raise ValueError("shard count exceeds Steep input file count")
+
+    shards: List[List[Path]] = [[] for _ in range(shard_count)]
+    totals = [0] * shard_count
+    ordered = sorted(files, key=lambda path: (-path.stat().st_size, path.as_posix()))
+    for path in ordered:
+        index = min(range(shard_count), key=lambda item: (totals[item], item))
+        shards[index].append(path)
+        totals[index] += path.stat().st_size
+
+    for shard in shards:
+        shard.sort(key=lambda path: path.as_posix())
+    return shards
+
+
+def command_for_shard(
+    root: Path, shard_index: int, shard_count: int, jobs: int
+) -> List[str]:
+    if not 0 <= shard_index < shard_count:
+        raise ValueError("shard index must be within the shard count")
+    if jobs < 1:
+        raise ValueError("jobs must be positive")
+
+    root = root.resolve()
+    shards = partition_steep_files(root, shard_count)
+    selected = [path.relative_to(root).as_posix() for path in shards[shard_index]]
+    return ["bundle", "exec", "steep", "check", f"--jobs={jobs}", *selected]
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--shard-index", type=int, required=True)
+    parser.add_argument("--shard-count", type=int, required=True)
+    parser.add_argument("--jobs", type=int, default=2)
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    root = Path.cwd().resolve()
+    command = command_for_shard(
+        root,
+        shard_index=args.shard_index,
+        shard_count=args.shard_count,
+        jobs=args.jobs,
+    )
+    selected = command[5:]
+    total_bytes = sum((root / path).stat().st_size for path in selected)
+    ruby_count = sum(path.endswith(".rb") for path in selected)
+    rbs_count = sum(path.endswith(".rbs") for path in selected)
+    print(
+        f"Running Steep shard {args.shard_index + 1}/{args.shard_count}: "
+        f"{ruby_count} Ruby files, {rbs_count} RBS files, "
+        f"{total_bytes} input bytes",
+        flush=True,
+    )
+    subprocess.run(command, cwd=root, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/run_steep_shards.py
+++ b/.github/scripts/run_steep_shards.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Dispatch and fail-closed poll four protected Steep worker runs."""
+
+import json
+import os
+import re
+import signal
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+WORKFLOW = "ci.yml"
+SHARD_COUNT = 4
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+CORRELATION_RE = re.compile(r"^[0-9]+-[0-9]+-[0-9a-f]{40}$")
+
+
+class ApiError(RuntimeError):
+    def __init__(self, status: int, message: str):
+        super().__init__(f"GitHub API returned {status}: {message}")
+        self.status = status
+
+
+class CancellationRequested(RuntimeError):
+    pass
+
+
+def install_signal_handlers() -> None:
+    def cancel(signum, _frame):
+        raise CancellationRequested(f"received signal {signum}")
+
+    signal.signal(signal.SIGINT, cancel)
+    signal.signal(signal.SIGTERM, cancel)
+
+
+class GitHubActionsApi:
+    """Minimal GitHub Actions REST boundary used by the orchestrator."""
+
+    def __init__(self, api_url: str, repository: str, token: str):
+        self.base = f"{api_url.rstrip('/')}/repos/{repository}"
+        self.token = token
+
+    def _request(self, method: str, path: str, payload=None):
+        data = None if payload is None else json.dumps(payload).encode()
+        request = urllib.request.Request(
+            f"{self.base}{path}",
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                body = response.read()
+                return None if not body else json.loads(body.decode())
+        except urllib.error.HTTPError as error:
+            body = error.read().decode(errors="replace")
+            raise ApiError(error.code, body) from error
+
+    def dispatch(self, ref: str, inputs: Dict[str, str]) -> None:
+        # Ref: https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event
+        self._request(
+            "POST",
+            f"/actions/workflows/{WORKFLOW}/dispatches",
+            {"ref": ref, "inputs": inputs},
+        )
+
+    def find_runs(self, correlation_id: str) -> List[dict]:
+        # Ref: https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-workflow
+        query = urllib.parse.urlencode({"event": "workflow_dispatch", "per_page": 100})
+        result = self._request(
+            "GET", f"/actions/workflows/{WORKFLOW}/runs?{query}"
+        )
+        prefix = f"Steep worker {correlation_id} · shard "
+        return [
+            run
+            for run in result.get("workflow_runs", [])
+            if run.get("display_title", run.get("name", "")).startswith(prefix)
+        ]
+
+    def get_run(self, run_id: int) -> dict:
+        return self._request("GET", f"/actions/runs/{run_id}")
+
+    def cancel(self, run_id: int) -> None:
+        try:
+            self._request("POST", f"/actions/runs/{run_id}/cancel")
+        except ApiError as error:
+            if error.status != 409:
+                raise
+
+
+def title_for(correlation_id: str, shard: int) -> str:
+    return f"Steep worker {correlation_id} · shard {shard}"
+
+
+def validate_inputs(target_sha: str, correlation_id: str, worker_ref: str) -> None:
+    if not SHA_RE.fullmatch(target_sha):
+        raise ValueError("TARGET_SHA must be a lowercase 40-character commit SHA")
+    if not CORRELATION_RE.fullmatch(correlation_id):
+        raise ValueError("CORRELATION_ID has an invalid shape")
+    if not worker_ref or any(character.isspace() for character in worker_ref):
+        raise ValueError("worker ref must be non-empty and contain no whitespace")
+
+
+def duration(run: dict) -> str:
+    start = run.get("run_started_at")
+    end = run.get("updated_at")
+    if not start or not end:
+        return "n/a"
+    started = datetime.fromisoformat(start.replace("Z", "+00:00"))
+    finished = datetime.fromisoformat(end.replace("Z", "+00:00"))
+    seconds = max(0, int((finished - started).total_seconds()))
+    return f"{seconds // 60}m {seconds % 60:02d}s"
+
+
+def write_summary(summary_path: Optional[Path], runs: Dict[int, dict]) -> None:
+    if summary_path is None:
+        return
+    lines = ["## Steep shards", "", "Four GitHub-hosted workers checked the same immutable commit.", ""]
+    for shard in range(SHARD_COUNT):
+        run = runs[shard]
+        icon = "✅" if run.get("conclusion") == "success" else "❌"
+        lines.append(
+            f"- Shard {shard}: {icon} [{duration(run)}]({run.get('html_url', '')})"
+        )
+    summary_path.write_text("\n".join(lines) + "\n")
+
+
+def orchestrate(
+    api,
+    worker_ref: str,
+    rollout_fallback_ref: str,
+    target_sha: str,
+    correlation_id: str,
+    summary_path: Optional[Path],
+    poll_seconds: float = 5,
+    timeout_seconds: float = 3300,
+) -> bool:
+    validate_inputs(target_sha, correlation_id, worker_ref)
+    dispatched_ref = worker_ref
+    inputs = {
+        "target_sha": target_sha,
+        "shard_index": "0",
+        "correlation_id": correlation_id,
+    }
+    try:
+        api.dispatch(dispatched_ref, inputs)
+    except ApiError as error:
+        if error.status != 422 or not rollout_fallback_ref:
+            raise
+        dispatched_ref = rollout_fallback_ref
+        api.dispatch(dispatched_ref, inputs)
+
+    for shard in range(1, SHARD_COUNT):
+        api.dispatch(
+            dispatched_ref,
+            {
+                "target_sha": target_sha,
+                "shard_index": str(shard),
+                "correlation_id": correlation_id,
+            },
+        )
+
+    deadline = time.monotonic() + timeout_seconds
+    run_ids: Dict[int, int] = {}
+    terminal_runs: Dict[int, dict] = {}
+    try:
+        while time.monotonic() < deadline:
+            for run in api.find_runs(correlation_id):
+                display_title = run.get("display_title", run.get("name", ""))
+                for shard in range(SHARD_COUNT):
+                    if display_title == title_for(correlation_id, shard):
+                        existing = run_ids.get(shard)
+                        if existing is not None and existing != run["id"]:
+                            raise RuntimeError(f"multiple worker runs found for shard {shard}")
+                        run_ids[shard] = run["id"]
+
+            for shard, run_id in run_ids.items():
+                run = api.get_run(run_id)
+                if run.get("status") == "completed":
+                    terminal_runs[shard] = run
+
+            if len(terminal_runs) == SHARD_COUNT:
+                write_summary(summary_path, terminal_runs)
+                failed = [
+                    shard
+                    for shard, run in terminal_runs.items()
+                    if run.get("conclusion") != "success"
+                ]
+                if failed:
+                    raise RuntimeError(f"Steep workers failed or were cancelled: {failed}")
+                return True
+            time.sleep(poll_seconds)
+    finally:
+        if len(terminal_runs) != SHARD_COUNT:
+            for shard, run_id in run_ids.items():
+                if shard not in terminal_runs:
+                    api.cancel(run_id)
+
+    missing = sorted(set(range(SHARD_COUNT)) - set(terminal_runs))
+    raise TimeoutError(f"Timed out waiting for Steep workers: {missing}")
+
+
+def main() -> int:
+    install_signal_handlers()
+    required = [
+        "GH_TOKEN",
+        "TARGET_SHA",
+        "CORRELATION_ID",
+        "PRIMARY_WORKER_REF",
+        "GITHUB_REPOSITORY",
+        "GITHUB_API_URL",
+    ]
+    missing = [name for name in required if not os.environ.get(name)]
+    if missing:
+        raise RuntimeError(f"Missing required environment variables: {missing}")
+
+    api = GitHubActionsApi(
+        os.environ["GITHUB_API_URL"],
+        os.environ["GITHUB_REPOSITORY"],
+        os.environ["GH_TOKEN"],
+    )
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    orchestrate(
+        api=api,
+        worker_ref=os.environ["PRIMARY_WORKER_REF"],
+        rollout_fallback_ref=os.environ.get("ROLLOUT_FALLBACK_REF", ""),
+        target_sha=os.environ["TARGET_SHA"],
+        correlation_id=os.environ["CORRELATION_ID"],
+        summary_path=Path(summary) if summary else None,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (ApiError, RuntimeError, TimeoutError, ValueError) as error:
+        print(f"Steep shard orchestration failed: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/.github/scripts/test_ci_runner_policy.py
+++ b/.github/scripts/test_ci_runner_policy.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+import unittest
+from pathlib import Path
+
+WORKFLOW = Path(__file__).parents[1] / "workflows" / "ci.yml"
+
+
+def job_block(text: str, name: str, next_name: str) -> str:
+    start = f"  {name}:\n"
+    end = f"\n  {next_name}:\n"
+    if text.count(start) != 1 or text.count(end) != 1:
+        raise AssertionError(f"unable to isolate {name} job")
+    return text.split(start, 1)[1].split(end, 1)[0]
+
+
+class CiRunnerPolicyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.workflow = WORKFLOW.read_text()
+
+    def test_production_steep_has_one_pr_facing_check_and_dispatched_workers(self) -> None:
+        self.assertNotIn("  lint-steep-shards:\n", self.workflow)
+        self.assertIn("workflow_dispatch:", self.workflow)
+        worker = job_block(self.workflow, "lint-steep-worker", "lint-steep-staging")
+        self.assertIn("runs-on: ubuntu-latest", worker)
+        self.assertIn("github.event_name == 'workflow_dispatch'", worker)
+        self.assertIn("github.ref == 'refs/heads/next'", worker)
+        self.assertNotIn("github.ref == 'refs/heads/master'", worker)
+        self.assertIn("run_steep_shard.py", worker)
+        self.assertIn("contents: read", worker)
+        self.assertIn("persist-credentials: false", worker)
+        self.assertNotIn("actions: write", worker)
+        self.assertNotIn("secrets.", worker)
+        self.assertIn('git rev-parse HEAD', worker)
+        self.assertIn('TARGET_SHA', worker)
+        steep = job_block(self.workflow, "lint-steep", "lint-sorbet")
+        self.assertIn("name: lint (steep)", steep)
+        self.assertIn("run_steep_shards.py", steep)
+
+    def test_staging_retains_internal_large_runner(self) -> None:
+        staging = job_block(self.workflow, "lint-steep-staging", "lint-steep")
+        self.assertIn("runs-on: telnyx-2xlarge", staging)
+        self.assertIn("github.repository == 'team-telnyx/telnyx-ruby-staging'", staging)
+        self.assertIn("bundle exec steep check --jobs=4", staging)
+
+    def test_aggregator_preserves_required_check_name_and_fails_closed(self) -> None:
+        steep = job_block(self.workflow, "lint-steep", "lint-sorbet")
+        self.assertIn("name: lint (steep)", steep)
+        self.assertIn("runs-on: ubuntu-latest", steep)
+        self.assertIn("if: always()", steep)
+        self.assertIn("needs:", steep)
+        self.assertIn("lint-steep-staging", steep)
+        self.assertNotIn("lint-steep-signatures", steep)
+        self.assertIn("actions: write", steep)
+        self.assertIn("TARGET_SHA:", steep)
+        self.assertIn("CORRELATION_ID:", steep)
+        self.assertIn("PRIMARY_WORKER_REF:", steep)
+        self.assertIn("PRIMARY_WORKER_REF: next", steep)
+        self.assertIn("Run fork-safe production Steep check", steep)
+        self.assertIn("exit 1", steep)
+
+    def test_existing_rubocop_check_runs_policy_tests(self) -> None:
+        rubocop = job_block(self.workflow, "lint-rubocop", "lint-steep-worker")
+        self.assertIn("python3 .github/scripts/test_ci_runner_policy.py", rubocop)
+        self.assertIn("python3 .github/scripts/test_run_steep_shard.py", rubocop)
+        self.assertIn("python3 .github/scripts/test_run_steep_shards.py", rubocop)
+        self.assertIn("name: lint (rubocop)", rubocop)
+
+    def test_push_ci_runs_only_on_long_lived_branches(self) -> None:
+        trigger = self.workflow.split("  push:\n", 1)[1].split("  pull_request:\n", 1)[0]
+        self.assertNotIn("- '**'", trigger)
+        for branch in ("main", "master", "next", "codegen/stl/**"):
+            self.assertIn(f"- '{branch}'", trigger)
+
+    def test_serial_production_signature_job_is_removed(self) -> None:
+        self.assertNotIn("  lint-steep-signatures:\n", self.workflow)
+        self.assertNotIn("--no-type-check --validate=project", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_run_steep_shard.py
+++ b/.github/scripts/test_run_steep_shard.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("run_steep_shard.py")
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("run_steep_shard", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise AssertionError("unable to load shard helper")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RunSteepShardTest(unittest.TestCase):
+    def test_shards_are_deterministic_disjoint_and_complete(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            files = []
+            for subdir, suffix, sizes in [
+                ("lib", ".rb", [80, 30, 10, 3]),
+                ("sig", ".rbs", [50, 20, 5]),
+            ]:
+                for index, size in enumerate(sizes):
+                    path = root / subdir / f"file_{index}{suffix}"
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_bytes(b"x" * size)
+                    files.append(path)
+            (root / "lib" / "ignored.txt").write_text("not a Steep input")
+
+            first = module.partition_steep_files(root, shard_count=3)
+            second = module.partition_steep_files(root, shard_count=3)
+
+            self.assertEqual(first, second)
+            flattened = [path for shard in first for path in shard]
+            self.assertCountEqual(flattened, [path.resolve() for path in files])
+            self.assertEqual(len(flattened), len(set(flattened)))
+
+    def test_greedy_partition_balances_input_bytes(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for index, size in enumerate([100, 80, 60, 40]):
+                path = root / "lib" / f"file_{index}.rb"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"x" * size)
+            for index, size in enumerate([90, 70, 50, 30]):
+                path = root / "sig" / f"file_{index}.rbs"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"x" * size)
+
+            shards = module.partition_steep_files(root, shard_count=4)
+            totals = [sum(path.stat().st_size for path in shard) for shard in shards]
+            self.assertLessEqual(max(totals) - min(totals), 30)
+
+    def test_rejects_invalid_shard_arguments_and_empty_inputs(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "lib").mkdir()
+            (root / "sig").mkdir()
+            with self.assertRaisesRegex(ValueError, "no Steep input files"):
+                module.partition_steep_files(root, shard_count=2)
+            with self.assertRaisesRegex(ValueError, "shard count"):
+                module.partition_steep_files(root, shard_count=0)
+            with self.assertRaisesRegex(ValueError, "shard index"):
+                module.command_for_shard(root, shard_index=2, shard_count=2, jobs=2)
+
+    def test_command_checks_selected_ruby_and_rbs_files(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for index, size in enumerate([40, 20]):
+                path = root / "lib" / f"file_{index}.rb"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"x" * size)
+            for index, size in enumerate([30, 10]):
+                path = root / "sig" / f"file_{index}.rbs"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"x" * size)
+
+            commands = [
+                module.command_for_shard(root, shard_index=index, shard_count=2, jobs=2)
+                for index in range(2)
+            ]
+            for command in commands:
+                self.assertEqual(
+                    command[:5],
+                    ["bundle", "exec", "steep", "check", "--jobs=2"],
+                )
+                self.assertNotIn("--validate=skip", command)
+                self.assertTrue(command[5:])
+            selected = [path for command in commands for path in command[5:]]
+            self.assertTrue(any(path.startswith("lib/") for path in selected))
+            self.assertTrue(any(path.startswith("sig/") for path in selected))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_run_steep_shards.py
+++ b/.github/scripts/test_run_steep_shards.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT = Path(__file__).with_name("run_steep_shards.py")
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("run_steep_shards", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise AssertionError("unable to load shard orchestrator")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeActionsApi:
+    def __init__(self):
+        self.dispatched = []
+        self.cancelled = []
+
+    def dispatch(self, ref, inputs):
+        self.dispatched.append((ref, inputs.copy()))
+
+    def find_runs(self, correlation_id):
+        return [
+            {
+                "id": 100 + shard,
+                "name": f"Steep worker {correlation_id} · shard {shard}",
+                "html_url": f"https://example.test/runs/{100 + shard}",
+                "status": "completed",
+                "conclusion": "success",
+                "run_started_at": "2026-08-15T00:00:00Z",
+                "updated_at": "2026-08-15T00:01:00Z",
+            }
+            for shard in range(4)
+        ]
+
+    def get_run(self, run_id):
+        return next(run for run in self.find_runs("123-1-" + "a" * 40) if run["id"] == run_id)
+
+    def cancel(self, run_id):
+        self.cancelled.append(run_id)
+
+
+class RunSteepShardsTest(unittest.TestCase):
+    def test_installs_handlers_so_parent_cancellation_reaches_workers(self):
+        module = load_module()
+        with mock.patch.object(module.signal, "signal") as install:
+            module.install_signal_handlers()
+        self.assertEqual(install.call_count, 2)
+
+    def test_dispatches_four_workers_and_reports_one_successful_summary(self):
+        module = load_module()
+        api = FakeActionsApi()
+        correlation = "123-1-" + "a" * 40
+        with tempfile.TemporaryDirectory() as directory:
+            summary = Path(directory) / "summary.md"
+            result = module.orchestrate(
+                api=api,
+                worker_ref="master",
+                rollout_fallback_ref="feature",
+                target_sha="a" * 40,
+                correlation_id=correlation,
+                summary_path=summary,
+                poll_seconds=0,
+                timeout_seconds=1,
+            )
+
+            self.assertTrue(result)
+            self.assertEqual([ref for ref, _ in api.dispatched], ["master"] * 4)
+            self.assertEqual(
+                [inputs["shard_index"] for _, inputs in api.dispatched],
+                ["0", "1", "2", "3"],
+            )
+            for _, inputs in api.dispatched:
+                self.assertEqual(inputs["target_sha"], "a" * 40)
+                self.assertEqual(inputs["correlation_id"], correlation)
+            text = summary.read_text()
+            self.assertIn("## Steep shards", text)
+            self.assertEqual(text.count("✅"), 4)
+
+    def test_fails_closed_when_any_worker_fails(self):
+        module = load_module()
+
+        class FailedWorkerApi(FakeActionsApi):
+            def get_run(self, run_id):
+                run = super().get_run(run_id).copy()
+                if run_id == 102:
+                    run["conclusion"] = "failure"
+                return run
+
+        api = FailedWorkerApi()
+        with tempfile.TemporaryDirectory() as directory:
+            summary = Path(directory) / "summary.md"
+            with self.assertRaisesRegex(RuntimeError, r"\[2\]"):
+                module.orchestrate(
+                    api=api,
+                    worker_ref="master",
+                    rollout_fallback_ref="feature",
+                    target_sha="a" * 40,
+                    correlation_id="123-1-" + "a" * 40,
+                    summary_path=summary,
+                    poll_seconds=0,
+                    timeout_seconds=1,
+                )
+            self.assertIn("Shard 2: ❌", summary.read_text())
+
+    def test_timeout_cancels_discovered_workers(self):
+        module = load_module()
+
+        class HangingWorkerApi(FakeActionsApi):
+            def find_runs(self, correlation_id):
+                runs = super().find_runs(correlation_id)[:2]
+                for run in runs:
+                    run["status"] = "in_progress"
+                    run["conclusion"] = None
+                return runs
+
+            def get_run(self, run_id):
+                return next(
+                    run
+                    for run in self.find_runs("123-1-" + "a" * 40)
+                    if run["id"] == run_id
+                )
+
+        api = HangingWorkerApi()
+        with self.assertRaisesRegex(TimeoutError, r"\[0, 1, 2, 3\]"):
+            module.orchestrate(
+                api=api,
+                worker_ref="master",
+                rollout_fallback_ref="feature",
+                target_sha="a" * 40,
+                correlation_id="123-1-" + "a" * 40,
+                summary_path=None,
+                poll_seconds=0.001,
+                timeout_seconds=0.01,
+            )
+        self.assertEqual(api.cancelled, [100, 101])
+
+    def test_rollout_falls_back_only_when_default_branch_dispatch_is_unavailable(self):
+        module = load_module()
+
+        class RolloutApi(FakeActionsApi):
+            def dispatch(self, ref, inputs):
+                if ref == "master":
+                    raise module.ApiError(422, "workflow_dispatch is not active yet")
+                super().dispatch(ref, inputs)
+
+        api = RolloutApi()
+        module.orchestrate(
+            api=api,
+            worker_ref="master",
+            rollout_fallback_ref="feature",
+            target_sha="a" * 40,
+            correlation_id="123-1-" + "a" * 40,
+            summary_path=None,
+            poll_seconds=0,
+            timeout_seconds=1,
+        )
+        self.assertEqual([ref for ref, _ in api.dispatched], ["feature"] * 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     # Never execute PR-controlled code in the default-branch cache scope. The feature branch is a
     # one-time rollout path; the durable worker control branch is `next`.
-    if: github.repository == 'team-telnyx/telnyx-ruby' && github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/next' || github.ref == 'refs/heads/ci/steep-single-check')
+    if: github.repository == 'team-telnyx/telnyx-ruby' && github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/next' || github.ref == 'refs/heads/ci/steep-single-check' || github.ref == 'refs/heads/ci/steep-worker-next')
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,33 @@
 name: CI
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Steep worker {0} · shard {1}', inputs.correlation_id, inputs.shard_index) || github.ref_name }}
 on:
   push:
     branches:
-      - '**'
-      - '!integrated/**'
-      - '!stl-preview-head/**'
-      - '!stl-preview-base/**'
-      - '!generated'
-      - '!codegen/**'
+      - 'main'
+      - 'master'
+      - 'next'
       - 'codegen/stl/**'
   pull_request:
     branches-ignore:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'
+  # Ref: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch
+  # workflow_dispatch runs triggered with GITHUB_TOKEN are explicitly supported. Workers run on
+  # the non-default `next` cache scope and check out the immutable target SHA without secrets.
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: Exact commit to type-check
+        required: true
+        type: string
+      shard_index:
+        description: Zero-based Steep shard index
+        required: true
+        type: string
+      correlation_id:
+        description: Unique parent-run correlation identifier
+        required: true
+        type: string
 
 jobs:
   lint-rubocop:
@@ -22,6 +37,11 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Validate CI runner policy
+        run: |-
+          python3 .github/scripts/test_ci_runner_policy.py
+          python3 .github/scripts/test_run_steep_shard.py
+          python3 .github/scripts/test_run_steep_shards.py
       - name: Set up Ruby
         uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
@@ -31,11 +51,52 @@ jobs:
       - name: Run rubocop
         run: bundle exec rake lint:rubocop
 
-  lint-steep:
+  lint-steep-worker:
     timeout-minutes: 60
-    name: lint (steep)
-    runs-on: ${{ github.repository == 'team-telnyx/telnyx-ruby-staging' && 'telnyx-2xlarge' || 'ubuntu-latest' }}
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    name: Steep worker
+    runs-on: ubuntu-latest
+    # Never execute PR-controlled code in the default-branch cache scope. The feature branch is a
+    # one-time rollout path; the durable worker control branch is `next`.
+    if: github.repository == 'team-telnyx/telnyx-ruby' && github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/next' || github.ref == 'refs/heads/ci/steep-single-check')
+    permissions:
+      contents: read
+    steps:
+      - name: Validate immutable worker inputs
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+          SHARD_INDEX: ${{ inputs.shard_index }}
+          CORRELATION_ID: ${{ inputs.correlation_id }}
+        run: |-
+          [[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$SHARD_INDEX" =~ ^[0-3]$ ]]
+          [[ "$CORRELATION_ID" =~ ^[0-9]+-[0-9]+-[0-9a-f]{40}$ ]]
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.target_sha }}
+          persist-credentials: false
+      - name: Verify exact checkout
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: test "$(git rev-parse HEAD)" = "$TARGET_SHA"
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
+        with:
+          bundler-cache: false
+      - run: bundle install
+      - name: Run Steep shard
+        env:
+          SHARD_INDEX: ${{ inputs.shard_index }}
+        run: |-
+          python3 .github/scripts/run_steep_shard.py \
+            --shard-index "$SHARD_INDEX" \
+            --shard-count 4 \
+            --jobs 2
+
+  lint-steep-staging:
+    timeout-minutes: 60
+    name: lint (steep staging)
+    runs-on: telnyx-2xlarge
+    if: github.repository == 'team-telnyx/telnyx-ruby-staging' && (github.event_name == 'push' || github.event_name == 'pull_request')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Fix tool cache permissions
@@ -44,10 +105,61 @@ jobs:
         uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           bundler-cache: false
-      - run: |-
-          bundle install
+      - run: bundle install
       - name: Run steep
         run: bundle exec steep check --jobs=4
+
+  lint-steep:
+    timeout-minutes: 60
+    name: lint (steep)
+    runs-on: ubuntu-latest
+    if: always() && (github.event_name == 'push' || github.event_name == 'pull_request')
+    needs:
+      - lint-steep-staging
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Check out CI orchestration
+        if: github.repository == 'team-telnyx/telnyx-ruby' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run production Steep workers
+        if: github.repository == 'team-telnyx/telnyx-ruby' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          CORRELATION_ID: ${{ github.run_id }}-${{ github.run_attempt }}-${{ github.event.pull_request.head.sha || github.sha }}
+          PRIMARY_WORKER_REF: next
+          ROLLOUT_FALLBACK_REF: ${{ github.head_ref || github.ref_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_STEP_SUMMARY: ${{ github.step_summary }}
+        run: python3 .github/scripts/run_steep_shards.py
+      - name: Run fork-safe production Steep check
+        if: github.repository == 'team-telnyx/telnyx-ruby' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Ruby for fork-safe check
+        if: github.repository == 'team-telnyx/telnyx-ruby' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
+        with:
+          bundler-cache: false
+      - name: Run fork-safe production Steep check
+        if: github.repository == 'team-telnyx/telnyx-ruby' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |-
+          bundle install
+          bundle exec steep check --jobs=2
+      - name: Verify staging Steep check
+        if: github.repository == 'team-telnyx/telnyx-ruby-staging'
+        env:
+          STAGING_RESULT: ${{ needs.lint-steep-staging.result }}
+        run: test "$STAGING_RESULT" = "success"
+      - name: Reject unsupported repository
+        if: github.repository != 'team-telnyx/telnyx-ruby' && github.repository != 'team-telnyx/telnyx-ruby-staging'
+        run: exit 1
 
   lint-sorbet:
     timeout-minutes: 20


### PR DESCRIPTION
## Summary
- install the exact production CI workflow and Steep helper set on the non-default `next` branch
- provide a branch-isolated worker control plane for production PR #338
- keep default-branch caches outside the trust boundary of PR-controlled Steep execution

## Why `next`
GitHub cache scope follows branch ancestry. Running dispatched PR code on default `master` can expose default-branch cache credentials, and CodeQL correctly blocks that pattern. `next` is a long-lived non-default production branch, so the four workers remain hidden from PR checks without executing untrusted code in the default cache scope.

## Validation
- 6 runner/workflow policy tests pass
- 4 deterministic shard tests pass
- 5 fail-closed orchestration tests pass
- `actionlint` and `git diff --check` pass

## Durability
Staging companion PR #233 restores this workflow and helper set from production `master` on every staging → `next` promotion.

## Merge ordering
1. Merge production `master` PR #338 after its rollout validation.
2. Merge this PR to `next`.
3. Merge staging PR #233 so future promotions preserve the control plane.
4. Run a final no-op PR validation proving only `lint (steep)` is attached to the PR head.