### PR TITLE
ci: install isolated Steep worker control plane

### DIFF
--- a/.github/scripts/run_steep_shards.py
+++ b/.github/scripts/run_steep_shards.py
@@ -138,7 +138,6 @@ def write_summary(summary_path: Optional[Path], runs: Dict[int, dict]) -> None:
 def orchestrate(
     api,
     worker_ref: str,
-    rollout_fallback_ref: str,
     target_sha: str,
     correlation_id: str,
     summary_path: Optional[Path],
@@ -146,23 +145,16 @@ def orchestrate(
     timeout_seconds: float = 3300,
 ) -> bool:
     validate_inputs(target_sha, correlation_id, worker_ref)
-    dispatched_ref = worker_ref
     inputs = {
         "target_sha": target_sha,
         "shard_index": "0",
         "correlation_id": correlation_id,
     }
-    try:
-        api.dispatch(dispatched_ref, inputs)
-    except ApiError as error:
-        if error.status != 422 or not rollout_fallback_ref:
-            raise
-        dispatched_ref = rollout_fallback_ref
-        api.dispatch(dispatched_ref, inputs)
+    api.dispatch(worker_ref, inputs)
 
     for shard in range(1, SHARD_COUNT):
         api.dispatch(
-            dispatched_ref,
+            worker_ref,
             {
                 "target_sha": target_sha,
                 "shard_index": str(shard),
@@ -233,7 +225,6 @@ def main() -> int:
     orchestrate(
         api=api,
         worker_ref=os.environ["PRIMARY_WORKER_REF"],
-        rollout_fallback_ref=os.environ.get("ROLLOUT_FALLBACK_REF", ""),
         target_sha=os.environ["TARGET_SHA"],
         correlation_id=os.environ["CORRELATION_ID"],
         summary_path=Path(summary) if summary else None,

--- a/.github/scripts/run_steep_shards.py
+++ b/.github/scripts/run_steep_shards.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Dispatch and fail-closed poll four protected Steep worker runs."""
+
+import json
+import os
+import re
+import signal
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+WORKFLOW = "ci.yml"
+SHARD_COUNT = 4
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+CORRELATION_RE = re.compile(r"^[0-9]+-[0-9]+-[0-9a-f]{40}$")
+
+
+class ApiError(RuntimeError):
+    def __init__(self, status: int, message: str):
+        super().__init__(f"GitHub API returned {status}: {message}")
+        self.status = status
+
+
+class CancellationRequested(RuntimeError):
+    pass
+
+
+def install_signal_handlers() -> None:
+    def cancel(signum, _frame):
+        raise CancellationRequested(f"received signal {signum}")
+
+    signal.signal(signal.SIGINT, cancel)
+    signal.signal(signal.SIGTERM, cancel)
+
+
+class GitHubActionsApi:
+    """Minimal GitHub Actions REST boundary used by the orchestrator."""
+
+    def __init__(self, api_url: str, repository: str, token: str):
+        self.base = f"{api_url.rstrip('/')}/repos/{repository}"
+        self.token = token
+
+    def _request(self, method: str, path: str, payload=None):
+        data = None if payload is None else json.dumps(payload).encode()
+        request = urllib.request.Request(
+            f"{self.base}{path}",
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                body = response.read()
+                return None if not body else json.loads(body.decode())
+        except urllib.error.HTTPError as error:
+            body = error.read().decode(errors="replace")
+            raise ApiError(error.code, body) from error
+
+    def dispatch(self, ref: str, inputs: Dict[str, str]) -> None:
+        # Ref: https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event
+        self._request(
+            "POST",
+            f"/actions/workflows/{WORKFLOW}/dispatches",
+            {"ref": ref, "inputs": inputs},
+        )
+
+    def find_runs(self, correlation_id: str) -> List[dict]:
+        # Ref: https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-workflow
+        query = urllib.parse.urlencode({"event": "workflow_dispatch", "per_page": 100})
+        result = self._request(
+            "GET", f"/actions/workflows/{WORKFLOW}/runs?{query}"
+        )
+        prefix = f"Steep worker {correlation_id} · shard "
+        return [
+            run
+            for run in result.get("workflow_runs", [])
+            if run.get("display_title", run.get("name", "")).startswith(prefix)
+        ]
+
+    def get_run(self, run_id: int) -> dict:
+        return self._request("GET", f"/actions/runs/{run_id}")
+
+    def cancel(self, run_id: int) -> None:
+        try:
+            self._request("POST", f"/actions/runs/{run_id}/cancel")
+        except ApiError as error:
+            if error.status != 409:
+                raise
+
+
+def title_for(correlation_id: str, shard: int) -> str:
+    return f"Steep worker {correlation_id} · shard {shard}"
+
+
+def validate_inputs(target_sha: str, correlation_id: str, worker_ref: str) -> None:
+    if not SHA_RE.fullmatch(target_sha):
+        raise ValueError("TARGET_SHA must be a lowercase 40-character commit SHA")
+    if not CORRELATION_RE.fullmatch(correlation_id):
+        raise ValueError("CORRELATION_ID has an invalid shape")
+    if not worker_ref or any(character.isspace() for character in worker_ref):
+        raise ValueError("worker ref must be non-empty and contain no whitespace")
+
+
+def duration(run: dict) -> str:
+    start = run.get("run_started_at")
+    end = run.get("updated_at")
+    if not start or not end:
+        return "n/a"
+    started = datetime.fromisoformat(start.replace("Z", "+00:00"))
+    finished = datetime.fromisoformat(end.replace("Z", "+00:00"))
+    seconds = max(0, int((finished - started).total_seconds()))
+    return f"{seconds // 60}m {seconds % 60:02d}s"
+
+
+def write_summary(summary_path: Optional[Path], runs: Dict[int, dict]) -> None:
+    if summary_path is None:
+        return
+    lines = ["## Steep shards", "", "Four GitHub-hosted workers checked the same immutable commit.", ""]
+    for shard in range(SHARD_COUNT):
+        run = runs[shard]
+        icon = "✅" if run.get("conclusion") == "success" else "❌"
+        lines.append(
+            f"- Shard {shard}: {icon} [{duration(run)}]({run.get('html_url', '')})"
+        )
+    summary_path.write_text("\n".join(lines) + "\n")
+
+
+def orchestrate(
+    api,
+    worker_ref: str,
+    rollout_fallback_ref: str,
+    target_sha: str,
+    correlation_id: str,
+    summary_path: Optional[Path],
+    poll_seconds: float = 5,
+    timeout_seconds: float = 3300,
+) -> bool:
+    validate_inputs(target_sha, correlation_id, worker_ref)
+    dispatched_ref = worker_ref
+    inputs = {
+        "target_sha": target_sha,
+        "shard_index": "0",
+        "correlation_id": correlation_id,
+    }
+    try:
+        api.dispatch(dispatched_ref, inputs)
+    except ApiError as error:
+        if error.status != 422 or not rollout_fallback_ref:
+            raise
+        dispatched_ref = rollout_fallback_ref
+        api.dispatch(dispatched_ref, inputs)
+
+    for shard in range(1, SHARD_COUNT):
+        api.dispatch(
+            dispatched_ref,
+            {
+                "target_sha": target_sha,
+                "shard_index": str(shard),
+                "correlation_id": correlation_id,
+            },
+        )
+
+    deadline = time.monotonic() + timeout_seconds
+    run_ids: Dict[int, int] = {}
+    terminal_runs: Dict[int, dict] = {}
+    try:
+        while time.monotonic() < deadline:
+            for run in api.find_runs(correlation_id):
+                display_title = run.get("display_title", run.get("name", ""))
+                for shard in range(SHARD_COUNT):
+                    if display_title == title_for(correlation_id, shard):
+                        existing = run_ids.get(shard)
+                        if existing is not None and existing != run["id"]:
+                            raise RuntimeError(f"multiple worker runs found for shard {shard}")
+                        run_ids[shard] = run["id"]
+
+            for shard, run_id in run_ids.items():
+                run = api.get_run(run_id)
+                if run.get("status") == "completed":
+                    terminal_runs[shard] = run
+
+            if len(terminal_runs) == SHARD_COUNT:
+                write_summary(summary_path, terminal_runs)
+                failed = [
+                    shard
+                    for shard, run in terminal_runs.items()
+                    if run.get("conclusion") != "success"
+                ]
+                if failed:
+                    raise RuntimeError(f"Steep workers failed or were cancelled: {failed}")
+                return True
+            time.sleep(poll_seconds)
+    finally:
+        if len(terminal_runs) != SHARD_COUNT:
+            for shard, run_id in run_ids.items():
+                if shard not in terminal_runs:
+                    api.cancel(run_id)
+
+    missing = sorted(set(range(SHARD_COUNT)) - set(terminal_runs))
+    raise TimeoutError(f"Timed out waiting for Steep workers: {missing}")
+
+
+def main() -> int:
+    install_signal_handlers()
+    required = [
+        "GH_TOKEN",
+        "TARGET_SHA",
+        "CORRELATION_ID",
+        "PRIMARY_WORKER_REF",
+        "GITHUB_REPOSITORY",
+        "GITHUB_API_URL",
+    ]
+    missing = [name for name in required if not os.environ.get(name)]
+    if missing:
+        raise RuntimeError(f"Missing required environment variables: {missing}")
+
+    api = GitHubActionsApi(
+        os.environ["GITHUB_API_URL"],
+        os.environ["GITHUB_REPOSITORY"],
+        os.environ["GH_TOKEN"],
+    )
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    orchestrate(
+        api=api,
+        worker_ref=os.environ["PRIMARY_WORKER_REF"],
+        rollout_fallback_ref=os.environ.get("ROLLOUT_FALLBACK_REF", ""),
+        target_sha=os.environ["TARGET_SHA"],
+        correlation_id=os.environ["CORRELATION_ID"],
+        summary_path=Path(summary) if summary else None,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (ApiError, RuntimeError, TimeoutError, ValueError) as error:
+        print(f"Steep shard orchestration failed: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/.github/scripts/test_ci_runner_policy.py
+++ b/.github/scripts/test_ci_runner_policy.py
@@ -17,14 +17,27 @@ class CiRunnerPolicyTest(unittest.TestCase):
     def setUp(self) -> None:
         self.workflow = WORKFLOW.read_text()
 
-    def test_production_steep_shards_use_github_hosted_runners(self) -> None:
-        shards = job_block(self.workflow, "lint-steep-shards", "lint-steep-staging")
-        self.assertIn("runs-on: ubuntu-latest", shards)
-        self.assertNotIn("telnyx-2xlarge", shards)
-        self.assertIn("matrix:", shards)
-        self.assertIn("shard: [0, 1, 2, 3]", shards)
-        self.assertIn("github.repository == 'team-telnyx/telnyx-ruby'", shards)
-        self.assertIn("run_steep_shard.py", shards)
+    def test_production_steep_has_one_pr_facing_check_and_dispatched_workers(self) -> None:
+        self.assertNotIn("  lint-steep-shards:\n", self.workflow)
+        self.assertIn("workflow_dispatch:", self.workflow)
+        worker = job_block(self.workflow, "lint-steep-worker", "lint-steep-staging")
+        self.assertIn("runs-on: ubuntu-latest", worker)
+        self.assertIn("github.event_name == 'workflow_dispatch'", worker)
+        self.assertIn("github.ref == 'refs/heads/ci/steep-workers'", worker)
+        self.assertNotIn("github.ref == 'refs/heads/master'", worker)
+        self.assertIn("run_steep_shard.py", worker)
+        self.assertIn("contents: read", worker)
+        self.assertIn("persist-credentials: false", worker)
+        self.assertNotIn("actions: write", worker)
+        self.assertNotIn("${{ secrets.", worker)
+        self.assertIn('git rev-parse HEAD', worker)
+        self.assertIn('TARGET_SHA', worker)
+        self.assertGreaterEqual(
+            worker.count("codeql[actions/cache-poisoning/poisonable-step]"), 4
+        )
+        steep = job_block(self.workflow, "lint-steep", "lint-sorbet")
+        self.assertIn("name: lint (steep)", steep)
+        self.assertIn("run_steep_shards.py", steep)
 
     def test_staging_retains_internal_large_runner(self) -> None:
         staging = job_block(self.workflow, "lint-steep-staging", "lint-steep")
@@ -38,16 +51,28 @@ class CiRunnerPolicyTest(unittest.TestCase):
         self.assertIn("runs-on: ubuntu-latest", steep)
         self.assertIn("if: always()", steep)
         self.assertIn("needs:", steep)
-        self.assertIn("lint-steep-shards", steep)
         self.assertIn("lint-steep-staging", steep)
         self.assertNotIn("lint-steep-signatures", steep)
+        self.assertIn("actions: write", steep)
+        self.assertIn("TARGET_SHA:", steep)
+        self.assertIn("CORRELATION_ID:", steep)
+        self.assertIn("PRIMARY_WORKER_REF:", steep)
+        self.assertIn("PRIMARY_WORKER_REF: ci/steep-workers", steep)
+        self.assertIn("Run fork-safe production Steep check", steep)
         self.assertIn("exit 1", steep)
 
     def test_existing_rubocop_check_runs_policy_tests(self) -> None:
-        rubocop = job_block(self.workflow, "lint-rubocop", "lint-steep-shards")
+        rubocop = job_block(self.workflow, "lint-rubocop", "lint-steep-worker")
         self.assertIn("python3 .github/scripts/test_ci_runner_policy.py", rubocop)
         self.assertIn("python3 .github/scripts/test_run_steep_shard.py", rubocop)
+        self.assertIn("python3 .github/scripts/test_run_steep_shards.py", rubocop)
         self.assertIn("name: lint (rubocop)", rubocop)
+
+    def test_push_ci_runs_only_on_long_lived_branches(self) -> None:
+        trigger = self.workflow.split("  push:\n", 1)[1].split("  pull_request:\n", 1)[0]
+        self.assertNotIn("- '**'", trigger)
+        for branch in ("main", "master", "next", "codegen/stl/**"):
+            self.assertIn(f"- '{branch}'", trigger)
 
     def test_serial_production_signature_job_is_removed(self) -> None:
         self.assertNotIn("  lint-steep-signatures:\n", self.workflow)

--- a/.github/scripts/test_run_steep_shards.py
+++ b/.github/scripts/test_run_steep_shards.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT = Path(__file__).with_name("run_steep_shards.py")
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("run_steep_shards", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise AssertionError("unable to load shard orchestrator")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeActionsApi:
+    def __init__(self):
+        self.dispatched = []
+        self.cancelled = []
+
+    def dispatch(self, ref, inputs):
+        self.dispatched.append((ref, inputs.copy()))
+
+    def find_runs(self, correlation_id):
+        return [
+            {
+                "id": 100 + shard,
+                "name": f"Steep worker {correlation_id} · shard {shard}",
+                "html_url": f"https://example.test/runs/{100 + shard}",
+                "status": "completed",
+                "conclusion": "success",
+                "run_started_at": "2026-08-15T00:00:00Z",
+                "updated_at": "2026-08-15T00:01:00Z",
+            }
+            for shard in range(4)
+        ]
+
+    def get_run(self, run_id):
+        return next(run for run in self.find_runs("123-1-" + "a" * 40) if run["id"] == run_id)
+
+    def cancel(self, run_id):
+        self.cancelled.append(run_id)
+
+
+class RunSteepShardsTest(unittest.TestCase):
+    def test_installs_handlers_so_parent_cancellation_reaches_workers(self):
+        module = load_module()
+        with mock.patch.object(module.signal, "signal") as install:
+            module.install_signal_handlers()
+        self.assertEqual(install.call_count, 2)
+
+    def test_dispatches_four_workers_and_reports_one_successful_summary(self):
+        module = load_module()
+        api = FakeActionsApi()
+        correlation = "123-1-" + "a" * 40
+        with tempfile.TemporaryDirectory() as directory:
+            summary = Path(directory) / "summary.md"
+            result = module.orchestrate(
+                api=api,
+                worker_ref="master",
+                rollout_fallback_ref="feature",
+                target_sha="a" * 40,
+                correlation_id=correlation,
+                summary_path=summary,
+                poll_seconds=0,
+                timeout_seconds=1,
+            )
+
+            self.assertTrue(result)
+            self.assertEqual([ref for ref, _ in api.dispatched], ["master"] * 4)
+            self.assertEqual(
+                [inputs["shard_index"] for _, inputs in api.dispatched],
+                ["0", "1", "2", "3"],
+            )
+            for _, inputs in api.dispatched:
+                self.assertEqual(inputs["target_sha"], "a" * 40)
+                self.assertEqual(inputs["correlation_id"], correlation)
+            text = summary.read_text()
+            self.assertIn("## Steep shards", text)
+            self.assertEqual(text.count("✅"), 4)
+
+    def test_fails_closed_when_any_worker_fails(self):
+        module = load_module()
+
+        class FailedWorkerApi(FakeActionsApi):
+            def get_run(self, run_id):
+                run = super().get_run(run_id).copy()
+                if run_id == 102:
+                    run["conclusion"] = "failure"
+                return run
+
+        api = FailedWorkerApi()
+        with tempfile.TemporaryDirectory() as directory:
+            summary = Path(directory) / "summary.md"
+            with self.assertRaisesRegex(RuntimeError, r"\[2\]"):
+                module.orchestrate(
+                    api=api,
+                    worker_ref="master",
+                    rollout_fallback_ref="feature",
+                    target_sha="a" * 40,
+                    correlation_id="123-1-" + "a" * 40,
+                    summary_path=summary,
+                    poll_seconds=0,
+                    timeout_seconds=1,
+                )
+            self.assertIn("Shard 2: ❌", summary.read_text())
+
+    def test_timeout_cancels_discovered_workers(self):
+        module = load_module()
+
+        class HangingWorkerApi(FakeActionsApi):
+            def find_runs(self, correlation_id):
+                runs = super().find_runs(correlation_id)[:2]
+                for run in runs:
+                    run["status"] = "in_progress"
+                    run["conclusion"] = None
+                return runs
+
+            def get_run(self, run_id):
+                return next(
+                    run
+                    for run in self.find_runs("123-1-" + "a" * 40)
+                    if run["id"] == run_id
+                )
+
+        api = HangingWorkerApi()
+        with self.assertRaisesRegex(TimeoutError, r"\[0, 1, 2, 3\]"):
+            module.orchestrate(
+                api=api,
+                worker_ref="master",
+                rollout_fallback_ref="feature",
+                target_sha="a" * 40,
+                correlation_id="123-1-" + "a" * 40,
+                summary_path=None,
+                poll_seconds=0.001,
+                timeout_seconds=0.01,
+            )
+        self.assertEqual(api.cancelled, [100, 101])
+
+    def test_rollout_falls_back_only_when_default_branch_dispatch_is_unavailable(self):
+        module = load_module()
+
+        class RolloutApi(FakeActionsApi):
+            def dispatch(self, ref, inputs):
+                if ref == "master":
+                    raise module.ApiError(422, "workflow_dispatch is not active yet")
+                super().dispatch(ref, inputs)
+
+        api = RolloutApi()
+        module.orchestrate(
+            api=api,
+            worker_ref="master",
+            rollout_fallback_ref="feature",
+            target_sha="a" * 40,
+            correlation_id="123-1-" + "a" * 40,
+            summary_path=None,
+            poll_seconds=0,
+            timeout_seconds=1,
+        )
+        self.assertEqual([ref for ref, _ in api.dispatched], ["feature"] * 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_run_steep_shards.py
+++ b/.github/scripts/test_run_steep_shards.py
@@ -61,8 +61,7 @@ class RunSteepShardsTest(unittest.TestCase):
             summary = Path(directory) / "summary.md"
             result = module.orchestrate(
                 api=api,
-                worker_ref="master",
-                rollout_fallback_ref="feature",
+                worker_ref="ci/steep-workers",
                 target_sha="a" * 40,
                 correlation_id=correlation,
                 summary_path=summary,
@@ -71,7 +70,9 @@ class RunSteepShardsTest(unittest.TestCase):
             )
 
             self.assertTrue(result)
-            self.assertEqual([ref for ref, _ in api.dispatched], ["master"] * 4)
+            self.assertEqual(
+                [ref for ref, _ in api.dispatched], ["ci/steep-workers"] * 4
+            )
             self.assertEqual(
                 [inputs["shard_index"] for _, inputs in api.dispatched],
                 ["0", "1", "2", "3"],
@@ -99,8 +100,7 @@ class RunSteepShardsTest(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, r"\[2\]"):
                 module.orchestrate(
                     api=api,
-                    worker_ref="master",
-                    rollout_fallback_ref="feature",
+                    worker_ref="ci/steep-workers",
                     target_sha="a" * 40,
                     correlation_id="123-1-" + "a" * 40,
                     summary_path=summary,
@@ -131,8 +131,7 @@ class RunSteepShardsTest(unittest.TestCase):
         with self.assertRaisesRegex(TimeoutError, r"\[0, 1, 2, 3\]"):
             module.orchestrate(
                 api=api,
-                worker_ref="master",
-                rollout_fallback_ref="feature",
+                worker_ref="ci/steep-workers",
                 target_sha="a" * 40,
                 correlation_id="123-1-" + "a" * 40,
                 summary_path=None,
@@ -141,27 +140,25 @@ class RunSteepShardsTest(unittest.TestCase):
             )
         self.assertEqual(api.cancelled, [100, 101])
 
-    def test_rollout_falls_back_only_when_default_branch_dispatch_is_unavailable(self):
+    def test_dispatch_failure_is_fail_closed_without_untrusted_ref_fallback(self):
         module = load_module()
 
-        class RolloutApi(FakeActionsApi):
+        class UnavailableApi(FakeActionsApi):
             def dispatch(self, ref, inputs):
-                if ref == "master":
-                    raise module.ApiError(422, "workflow_dispatch is not active yet")
-                super().dispatch(ref, inputs)
+                raise module.ApiError(422, "workflow_dispatch is unavailable")
 
-        api = RolloutApi()
-        module.orchestrate(
-            api=api,
-            worker_ref="master",
-            rollout_fallback_ref="feature",
-            target_sha="a" * 40,
-            correlation_id="123-1-" + "a" * 40,
-            summary_path=None,
-            poll_seconds=0,
-            timeout_seconds=1,
-        )
-        self.assertEqual([ref for ref, _ in api.dispatched], ["feature"] * 4)
+        api = UnavailableApi()
+        with self.assertRaises(module.ApiError):
+            module.orchestrate(
+                api=api,
+                worker_ref="ci/steep-workers",
+                target_sha="a" * 40,
+                correlation_id="123-1-" + "a" * 40,
+                summary_path=None,
+                poll_seconds=0,
+                timeout_seconds=1,
+            )
+        self.assertEqual(api.dispatched, [])
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_steep_worker_control.py
+++ b/.github/scripts/test_steep_worker_control.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import unittest
+from pathlib import Path
+
+WORKFLOW = Path(__file__).parents[1] / "workflows" / "ci.yml"
+
+
+class SteepWorkerControlTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text()
+
+    def test_control_workflow_has_no_normal_sdk_ci_or_privileged_execution(self) -> None:
+        self.assertIn("name: Steep Worker Control", self.workflow)
+        self.assertIn("workflow_dispatch:", self.workflow)
+        self.assertIn("refs/heads/ci/steep-workers", self.workflow)
+        self.assertNotIn("lint-rubocop:", self.workflow)
+        self.assertNotIn("lint-steep:", self.workflow)
+        self.assertNotIn("secrets.", self.workflow)
+        self.assertNotIn("actions: write", self.workflow)
+
+    def test_worker_is_exact_sha_read_only_and_four_way_sharded(self) -> None:
+        self.assertIn("contents: read", self.workflow)
+        self.assertIn("persist-credentials: false", self.workflow)
+        self.assertIn('git rev-parse HEAD', self.workflow)
+        self.assertIn("--shard-count 4", self.workflow)
+        self.assertIn("run_steep_shard.py", self.workflow)
+        self.assertIn("bundler-cache: false", self.workflow)
+
+    def test_control_pr_runs_local_policy_tests_only(self) -> None:
+        self.assertIn("github.event_name == 'pull_request'", self.workflow)
+        self.assertIn("test_steep_worker_control.py", self.workflow)
+        self.assertIn("test_run_steep_shard.py", self.workflow)
+        self.assertIn("test_run_steep_shards.py", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,16 @@
-name: CI
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('Steep worker {0} · shard {1}', inputs.correlation_id, inputs.shard_index) || github.ref_name }}
+name: Steep Worker Control
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Steep worker {0} · shard {1}', inputs.correlation_id, inputs.shard_index) || format('Worker control PR · {0}', github.head_ref) }}
 on:
-  push:
-    branches:
-      - 'main'
-      - 'master'
-      - 'next'
-      - 'codegen/stl/**'
   pull_request:
-    branches-ignore:
-      - 'stl-preview-head/**'
-      - 'stl-preview-base/**'
-  # Ref: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch
-  # workflow_dispatch runs triggered with GITHUB_TOKEN are explicitly supported. Workers run on
-  # a dedicated non-default cache scope and check out the immutable target SHA without secrets.
+    branches:
+      - 'ci/steep-workers'
+    paths:
+      - '.github/workflows/ci.yml'
+      - '.github/scripts/run_steep_shard.py'
+      - '.github/scripts/run_steep_shards.py'
+      - '.github/scripts/test_run_steep_shard.py'
+      - '.github/scripts/test_run_steep_shards.py'
+      - '.github/scripts/test_steep_worker_control.py'
   workflow_dispatch:
     inputs:
       target_sha:
@@ -29,35 +26,31 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
-  lint-rubocop:
-    timeout-minutes: 10
-    name: lint (rubocop)
+  control-policy:
+    if: github.event_name == 'pull_request'
+    name: worker control policy
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Validate CI runner policy
+        with:
+          persist-credentials: false
+      - name: Validate worker control plane
         run: |-
-          python3 .github/scripts/test_ci_runner_policy.py
+          python3 .github/scripts/test_steep_worker_control.py
           python3 .github/scripts/test_run_steep_shard.py
           python3 .github/scripts/test_run_steep_shards.py
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
-        with:
-          bundler-cache: false
-      - run: |-
-          bundle install
-      - name: Run rubocop
-        run: bundle exec rake lint:rubocop
 
-  lint-steep-worker:
-    timeout-minutes: 60
+  steep-worker:
+    if: github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/ci/steep-workers' || github.ref == 'refs/heads/ci/install-steep-workers')
     name: Steep worker
     runs-on: ubuntu-latest
-    # Never execute PR-controlled code in the default-branch cache scope. The feature branches are
-    # one-time rollout paths; the durable control branch runs no privileged workflows or secrets.
-    if: github.repository == 'team-telnyx/telnyx-ruby' && github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/ci/steep-workers' || github.ref == 'refs/heads/ci/steep-single-check' || github.ref == 'refs/heads/ci/install-steep-workers')
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -70,9 +63,6 @@ jobs:
           [[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$SHARD_INDEX" =~ ^[0-3]$ ]]
           [[ "$CORRELATION_ID" =~ ^[0-9]+-[0-9]+-[0-9a-f]{40}$ ]]
-      # codeql[actions/cache-poisoning/poisonable-step]
-      # Safe: branch-gated above to an isolated non-default cache scope, with no secrets,
-      # no privileged cache consumers, a read-only token, and no persisted credentials.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.target_sha }}
@@ -81,17 +71,11 @@ jobs:
         env:
           TARGET_SHA: ${{ inputs.target_sha }}
         run: test "$(git rev-parse HEAD)" = "$TARGET_SHA"
-      # codeql[actions/cache-poisoning/poisonable-step]
-      # Safe for the same isolated-scope reason documented above; Bundler caching is disabled.
       - name: Set up Ruby
         uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           bundler-cache: false
-      # codeql[actions/cache-poisoning/poisonable-step]
-      # Safe for the same isolated-scope reason documented above.
       - run: bundle install
-      # codeql[actions/cache-poisoning/poisonable-step]
-      # Safe for the same isolated-scope reason documented above.
       - name: Run Steep shard
         env:
           SHARD_INDEX: ${{ inputs.shard_index }}
@@ -100,105 +84,3 @@ jobs:
             --shard-index "$SHARD_INDEX" \
             --shard-count 4 \
             --jobs 2
-
-  lint-steep-staging:
-    timeout-minutes: 60
-    name: lint (steep staging)
-    runs-on: telnyx-2xlarge
-    if: github.repository == 'team-telnyx/telnyx-ruby-staging' && (github.event_name == 'push' || github.event_name == 'pull_request')
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Fix tool cache permissions
-        run: sudo mkdir -p /opt/hostedtoolcache && sudo chmod 777 /opt/hostedtoolcache
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
-        with:
-          bundler-cache: false
-      - run: bundle install
-      - name: Run steep
-        run: bundle exec steep check --jobs=4
-
-  lint-steep:
-    timeout-minutes: 60
-    name: lint (steep)
-    runs-on: ubuntu-latest
-    if: always() && (github.event_name == 'push' || github.event_name == 'pull_request')
-    needs:
-      - lint-steep-staging
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - name: Check out CI orchestration
-        if: github.repository == 'team-telnyx/telnyx-ruby' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Run production Steep workers
-        if: github.repository == 'team-telnyx/telnyx-ruby' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          CORRELATION_ID: ${{ github.run_id }}-${{ github.run_attempt }}-${{ github.event.pull_request.head.sha || github.sha }}
-          PRIMARY_WORKER_REF: ci/steep-workers
-          ROLLOUT_FALLBACK_REF: ${{ github.head_ref || github.ref_name }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_API_URL: ${{ github.api_url }}
-          GITHUB_STEP_SUMMARY: ${{ github.step_summary }}
-        run: python3 .github/scripts/run_steep_shards.py
-      - name: Run fork-safe production Steep check
-        if: github.repository == 'team-telnyx/telnyx-ruby' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Set up Ruby for fork-safe check
-        if: github.repository == 'team-telnyx/telnyx-ruby' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
-        with:
-          bundler-cache: false
-      - name: Run fork-safe production Steep check
-        if: github.repository == 'team-telnyx/telnyx-ruby' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-        run: |-
-          bundle install
-          bundle exec steep check --jobs=2
-      - name: Verify staging Steep check
-        if: github.repository == 'team-telnyx/telnyx-ruby-staging'
-        env:
-          STAGING_RESULT: ${{ needs.lint-steep-staging.result }}
-        run: test "$STAGING_RESULT" = "success"
-      - name: Reject unsupported repository
-        if: github.repository != 'team-telnyx/telnyx-ruby' && github.repository != 'team-telnyx/telnyx-ruby-staging'
-        run: exit 1
-
-  lint-sorbet:
-    timeout-minutes: 20
-    name: lint (sorbet)
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
-        with:
-          bundler-cache: false
-      - run: |-
-          bundle install
-      - name: Run sorbet
-        run: bundle exec rake typecheck:sorbet
-
-  test:
-    timeout-minutes: 10
-    name: test
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
-        with:
-          bundler-cache: false
-      - run: |-
-          bundle install
-
-      - name: Run tests
-        run: ./scripts/test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,33 @@
 name: CI
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Steep worker {0} · shard {1}', inputs.correlation_id, inputs.shard_index) || github.ref_name }}
 on:
   push:
     branches:
-      - '**'
-      - '!integrated/**'
-      - '!stl-preview-head/**'
-      - '!stl-preview-base/**'
-      - '!generated'
-      - '!codegen/**'
+      - 'main'
+      - 'master'
+      - 'next'
       - 'codegen/stl/**'
   pull_request:
     branches-ignore:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'
+  # Ref: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch
+  # workflow_dispatch runs triggered with GITHUB_TOKEN are explicitly supported. Workers run on
+  # a dedicated non-default cache scope and check out the immutable target SHA without secrets.
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: Exact commit to type-check
+        required: true
+        type: string
+      shard_index:
+        description: Zero-based Steep shard index
+        required: true
+        type: string
+      correlation_id:
+        description: Unique parent-run correlation identifier
+        required: true
+        type: string
 
 jobs:
   lint-rubocop:
@@ -26,6 +41,7 @@ jobs:
         run: |-
           python3 .github/scripts/test_ci_runner_policy.py
           python3 .github/scripts/test_run_steep_shard.py
+          python3 .github/scripts/test_run_steep_shards.py
       - name: Set up Ruby
         uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
@@ -35,26 +51,53 @@ jobs:
       - name: Run rubocop
         run: bundle exec rake lint:rubocop
 
-  lint-steep-shards:
+  lint-steep-worker:
     timeout-minutes: 60
-    name: lint (steep shard ${{ matrix.shard }})
+    name: Steep worker
     runs-on: ubuntu-latest
-    if: github.repository == 'team-telnyx/telnyx-ruby' && (github.event_name == 'push' || github.event_name == 'pull_request')
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [0, 1, 2, 3]
+    # Never execute PR-controlled code in the default-branch cache scope. The feature branches are
+    # one-time rollout paths; the durable control branch runs no privileged workflows or secrets.
+    if: github.repository == 'team-telnyx/telnyx-ruby' && github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/ci/steep-workers' || github.ref == 'refs/heads/ci/steep-single-check' || github.ref == 'refs/heads/ci/install-steep-workers')
+    permissions:
+      contents: read
     steps:
+      - name: Validate immutable worker inputs
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+          SHARD_INDEX: ${{ inputs.shard_index }}
+          CORRELATION_ID: ${{ inputs.correlation_id }}
+        run: |-
+          [[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$SHARD_INDEX" =~ ^[0-3]$ ]]
+          [[ "$CORRELATION_ID" =~ ^[0-9]+-[0-9]+-[0-9a-f]{40}$ ]]
+      # codeql[actions/cache-poisoning/poisonable-step]
+      # Safe: branch-gated above to an isolated non-default cache scope, with no secrets,
+      # no privileged cache consumers, a read-only token, and no persisted credentials.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.target_sha }}
+          persist-credentials: false
+      - name: Verify exact checkout
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
+        run: test "$(git rev-parse HEAD)" = "$TARGET_SHA"
+      # codeql[actions/cache-poisoning/poisonable-step]
+      # Safe for the same isolated-scope reason documented above; Bundler caching is disabled.
       - name: Set up Ruby
         uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           bundler-cache: false
+      # codeql[actions/cache-poisoning/poisonable-step]
+      # Safe for the same isolated-scope reason documented above.
       - run: bundle install
+      # codeql[actions/cache-poisoning/poisonable-step]
+      # Safe for the same isolated-scope reason documented above.
       - name: Run Steep shard
+        env:
+          SHARD_INDEX: ${{ inputs.shard_index }}
         run: |-
           python3 .github/scripts/run_steep_shard.py \
-            --shard-index "${{ matrix.shard }}" \
+            --shard-index "$SHARD_INDEX" \
             --shard-count 4 \
             --jobs 2
 
@@ -76,29 +119,56 @@ jobs:
         run: bundle exec steep check --jobs=4
 
   lint-steep:
-    timeout-minutes: 5
+    timeout-minutes: 60
     name: lint (steep)
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && (github.event_name == 'push' || github.event_name == 'pull_request')
     needs:
-      - lint-steep-shards
       - lint-steep-staging
+    permissions:
+      actions: write
+      contents: read
     steps:
-      - name: Verify repository-specific Steep checks
+      - name: Check out CI orchestration
+        if: github.repository == 'team-telnyx/telnyx-ruby' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run production Steep workers
+        if: github.repository == 'team-telnyx/telnyx-ruby' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         env:
-          SHARDS_RESULT: ${{ needs.lint-steep-shards.result }}
-          STAGING_RESULT: ${{ needs.lint-steep-staging.result }}
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          CORRELATION_ID: ${{ github.run_id }}-${{ github.run_attempt }}-${{ github.event.pull_request.head.sha || github.sha }}
+          PRIMARY_WORKER_REF: ci/steep-workers
+          ROLLOUT_FALLBACK_REF: ${{ github.head_ref || github.ref_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_STEP_SUMMARY: ${{ github.step_summary }}
+        run: python3 .github/scripts/run_steep_shards.py
+      - name: Run fork-safe production Steep check
+        if: github.repository == 'team-telnyx/telnyx-ruby' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Ruby for fork-safe check
+        if: github.repository == 'team-telnyx/telnyx-ruby' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
+        with:
+          bundler-cache: false
+      - name: Run fork-safe production Steep check
+        if: github.repository == 'team-telnyx/telnyx-ruby' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
         run: |-
-          if [[ "${{ github.repository }}" == "team-telnyx/telnyx-ruby" ]]; then
-            [[ "$SHARDS_RESULT" == "success" ]] || exit 1
-            [[ "$STAGING_RESULT" == "skipped" ]] || exit 1
-          elif [[ "${{ github.repository }}" == "team-telnyx/telnyx-ruby-staging" ]]; then
-            [[ "$SHARDS_RESULT" == "skipped" ]] || exit 1
-            [[ "$STAGING_RESULT" == "success" ]] || exit 1
-          else
-            echo "Unsupported repository for Steep CI: ${{ github.repository }}"
-            exit 1
-          fi
+          bundle install
+          bundle exec steep check --jobs=2
+      - name: Verify staging Steep check
+        if: github.repository == 'team-telnyx/telnyx-ruby-staging'
+        env:
+          STAGING_RESULT: ${{ needs.lint-steep-staging.result }}
+        run: test "$STAGING_RESULT" = "success"
+      - name: Reject unsupported repository
+        if: github.repository != 'team-telnyx/telnyx-ruby' && github.repository != 'team-telnyx/telnyx-ruby-staging'
+        run: exit 1
 
   lint-sorbet:
     timeout-minutes: 20


### PR DESCRIPTION
## Summary
- install a worker-only CI control workflow on dedicated protected branch `ci/steep-workers`
- retain four independent GitHub-hosted Steep workers and deterministic partitioning
- keep worker runs out of normal production PR check suites
- fail closed instead of falling back to a PR-controlled worker ref

## Security boundary
- worker control/cache scope is non-default and contains no release, publish, or secret-bearing workflow
- workers have only `contents: read`, receive no secrets, disable Bundler caching, and do not persist checkout credentials
- workers validate and check out the exact immutable target SHA
- repository ruleset `20896955` blocks deletion, non-fast-forward updates, and direct changes to `ci/steep-workers`; updates must use a PR

## Local validation
- 3 control-workflow policy tests pass
- 4 deterministic shard tests pass
- 5 fail-closed orchestration tests pass
- `actionlint` and `git diff --check` pass

## Exact-head hosted validation
Control head: `504b40a656ea83d1fcee60b1f19b2e74082a43a1`
Target production head: `542eb25d1917af018c281965a44ceeee44b15f43`

Four concurrent workers passed on four distinct `ubuntu-latest` GitHub-hosted runners:
- shard 0: run `31912408856`, 16m29s
- shard 1: run `31912409813`, 16m17s
- shard 2: run `31912410715`, 18m29s
- shard 3: run `31912411675`, 14m23s

The 18m31s overall worker window remains aligned with the known-good ~18-minute sharded baseline.

## Durability
Staging PR #233 restores the production-owned aggregator workflow and helper files during full-tree promotions. The protected worker control branch is intentionally outside staging promotion.