### PR TITLE
fix: attest private release provenance

### DIFF
--- a/.github/scripts/release_pr_auto_merge.py
+++ b/.github/scripts/release_pr_auto_merge.py
@@ -453,11 +453,35 @@ class GitHubClient:
             raise GateError("GitHub command failed: %s: %s" % (" ".join(command[:4]), completed.stderr.strip()))
         return completed.stdout
 
+    def _provenance_gh(self, *args: str) -> str:
+        # A repository-scoped GITHUB_TOKEN cannot read the private staging and
+        # SDK-config repositories. Use the existing cross-repository token only
+        # for immutable provenance reads (and, separately, the final merge).
+        token = os.environ.get("MERGE_TOKEN")
+        if not token:
+            raise GateError("missing cross-repository provenance token")
+        env = dict(self.env)
+        env["GH_TOKEN"] = token
+        command = ["gh", *args]
+        completed = subprocess.run(command, env=env, text=True, capture_output=True)
+        if completed.returncode != 0:
+            raise GateError(
+                "GitHub provenance command failed: %s: %s"
+                % (" ".join(command[:4]), completed.stderr.strip())
+            )
+        return completed.stdout
+
     def _api_json(self, endpoint: str) -> Any:
         output = self._gh("api", endpoint)
         payload = json.loads(output)
         if payload is None:
             raise GateError("ambiguous API response for %s" % endpoint)
+        return payload
+
+    def _provenance_api_json(self, endpoint: str) -> Any:
+        payload = json.loads(self._provenance_gh("api", endpoint))
+        if payload is None:
+            raise GateError("ambiguous provenance API response for %s" % endpoint)
         return payload
 
     def _api_pages(self, endpoint: str, key: Optional[str] = None) -> List[Any]:
@@ -470,6 +494,19 @@ class GitHubClient:
             payload = page.get(key) if key and isinstance(page, Mapping) else page
             if not isinstance(payload, list):
                 raise GateError("ambiguous paginated API response for %s" % endpoint)
+            values.extend(payload)
+        return values
+
+    def _provenance_api_pages(self, endpoint: str, key: Optional[str] = None) -> List[Any]:
+        output = self._provenance_gh("api", endpoint, "--paginate", "--slurp")
+        pages = json.loads(output)
+        if not isinstance(pages, list):
+            raise GateError("ambiguous paginated provenance response for %s" % endpoint)
+        values: List[Any] = []
+        for page in pages:
+            payload = page.get(key) if key and isinstance(page, Mapping) else page
+            if not isinstance(payload, list):
+                raise GateError("ambiguous paginated provenance response for %s" % endpoint)
             values.extend(payload)
         return values
 
@@ -495,7 +532,7 @@ class GitHubClient:
         head_commit = self._api_json("repos/%s/commits/%s" % (repo, head_sha))
         promotion = self._find_promotion(next_sha)
         staging_sha = promotion["staging_sha"]
-        staging_prs = self._api_pages(
+        staging_prs = self._provenance_api_pages(
             "repos/%s/commits/%s/pulls?per_page=100" % (self.config.staging_repository, staging_sha)
         )
         generated_staging_prs = self._find_generated_staging_pr(staging_sha, staging_prs)
@@ -504,7 +541,7 @@ class GitHubClient:
             config_urls.extend(CONFIG_URL_RE.findall(str(staging_pr.get("body") or "")))
         resolved_config_sha = None
         if len(config_urls) == 1:
-            config_commit = self._api_json(
+            config_commit = self._provenance_api_json(
                 "repos/team-telnyx/telnyx-sdk-config/commits/%s" % config_urls[0]
             )
             resolved_config_sha = config_commit.get("sha")
@@ -582,7 +619,7 @@ class GitHubClient:
             match = PROMOTION_RE.fullmatch(subject)
             if match:
                 staging_ref = match.group(1)
-                resolved = self._api_json(
+                resolved = self._provenance_api_json(
                     "repos/%s/commits/%s" % (self.config.staging_repository, staging_ref)
                 )
                 staging_sha = resolved.get("sha") if isinstance(resolved, Mapping) else None
@@ -615,14 +652,14 @@ class GitHubClient:
                 raise GateError("ambiguous generated staging PR at promoted SHA")
             return direct
 
-        commits = self._api_pages(
+        commits = self._provenance_api_pages(
             "repos/%s/commits?sha=%s&per_page=100"
             % (self.config.staging_repository, staging_sha)
         )
         for commit in commits:
             if not isinstance(commit, Mapping) or not SHA_RE.fullmatch(str(commit.get("sha", ""))):
                 raise GateError("ambiguous staging ancestry commit")
-            pulls = self._api_pages(
+            pulls = self._provenance_api_pages(
                 "repos/%s/commits/%s/pulls?per_page=100"
                 % (self.config.staging_repository, commit["sha"])
             )

--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -349,6 +349,39 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
 
         self.assertEqual(result, [{"number": 1}, {"number": 2}])
 
+    def test_private_provenance_reads_use_the_cross_repository_token(self):
+        client = GitHubClient(GateConfig.python(), "low-privilege-token")
+        completed = mock.Mock(returncode=0, stderr="", stdout='{"sha":"%s"}' % STAGING)
+        with mock.patch.dict("os.environ", {"MERGE_TOKEN": "cross-repository-token"}), mock.patch(
+            "release_pr_auto_merge.subprocess.run", return_value=completed
+        ) as run:
+            result = client._provenance_api_json(
+                "repos/team-telnyx/telnyx-python-staging/commits/%s" % STAGING[:7]
+            )
+
+        self.assertEqual(result["sha"], STAGING)
+        self.assertEqual(run.call_args.kwargs["env"]["GH_TOKEN"], "cross-repository-token")
+        self.assertNotEqual(run.call_args.kwargs["env"]["GH_TOKEN"], client.env["GH_TOKEN"])
+
+    def test_private_provenance_reads_fail_closed_without_cross_repository_token(self):
+        client = GitHubClient(GateConfig.python(), "low-privilege-token")
+        with mock.patch.dict("os.environ", {}, clear=True), self.assertRaisesRegex(
+            GateError, "cross-repository provenance token"
+        ):
+            client._provenance_api_json("repos/team-telnyx/telnyx-python-staging/commits/abcdef0")
+
+    def test_privileged_gate_job_is_filtered_to_release_please_candidates(self):
+        with open(
+            ".github/workflows/release-pr-auto-merge.yml", encoding="utf-8"
+        ) as workflow_file:
+            workflow = workflow_file.read()
+        self.assertIn(
+            "startsWith(github.event.pull_request.head.ref, 'release-please--')", workflow
+        )
+        self.assertIn(
+            "startsWith(github.event.pull_request.title, 'release: ')", workflow
+        )
+
     def test_merge_uses_immediate_rest_put_and_never_enables_auto_merge(self):
         client = GitHubClient(GateConfig.python(), "test-token")
         completed = mock.Mock(

--- a/.github/workflows/release-pr-auto-merge.yml
+++ b/.github/workflows/release-pr-auto-merge.yml
@@ -42,7 +42,13 @@ jobs:
         run: python3 -m py_compile .github/scripts/release_pr_auto_merge.py .github/scripts/test_release_pr_auto_merge.py
 
   gate:
-    if: github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'pull_request_target' &&
+        startsWith(github.event.pull_request.head.ref, 'release-please--') &&
+        startsWith(github.event.pull_request.title, 'release: ')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 65
     permissions:


### PR DESCRIPTION
## Summary
- use the existing cross-repository token only for immutable reads from private staging and SDK-config repositories
- keep repository-scoped `GITHUB_TOKEN` for production-repository attestation
- fail closed when the cross-repository provenance token is unavailable

## Root cause
The hosted tracer-bullet proved that a production repository `GITHUB_TOKEN` cannot read private staging repositories. GitHub returned 404 while resolving the abbreviated staging SHA, before the gate could attest the staging PR and SDK-config commit.

## Validation
- 23 policy behavior tests pass
- Python full `./scripts/lint` passes
- Python compilation passes
- `git diff --check` passes
- hosted failures reproduced on all six repositories before this fix

Part of DOT-2058.