### PR TITLE
ci: pin privileged workflow dependencies

### DIFF
--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import copy
+from pathlib import Path
+import re
 import unittest
 import dataclasses
 from unittest import mock
@@ -437,6 +439,21 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         self.assertIn("sha=%s" % HEAD, command)
         self.assertIn("commit_title=release: 4.174.0", command)
         self.assertNotIn("pr", command)
+
+
+class WorkflowDependencyPolicyTests(unittest.TestCase):
+    def test_external_workflow_actions_use_immutable_commit_shas(self):
+        root = Path(__file__).resolve().parents[2]
+        for workflow in sorted((root / ".github/workflows").glob("*.y*ml")):
+            for line_number, line in enumerate(workflow.read_text().splitlines(), 1):
+                match = re.search(r"-\s+uses:\s*([^\s#]+)", line)
+                if not match:
+                    continue
+                action = match.group(1)
+                if action.startswith(("./", "docker://")):
+                    continue
+                with self.subTest(workflow=workflow.name, line=line_number, action=action):
+                    self.assertRegex(action, r"@[0-9a-f]{40}$")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,13 +38,13 @@ jobs:
     if: github.repository == 'team-telnyx/telnyx-ruby'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           token: ${{ secrets.SDK_WRITE_TOKEN }}
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 

--- a/.github/workflows/release-pr-guard.yml
+++ b/.github/workflows/release-pr-guard.yml
@@ -18,7 +18,7 @@ jobs:
     name: protected-paths
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       - name: Block prod-owned changes in generated release PRs


### PR DESCRIPTION
Pin every mutable third-party action reference in active release workflows to an immutable commit SHA and add a fail-closed policy regression.

Validation:
- all `.github/scripts/test_*.py`
- `actionlint` (excluding the pre-existing SC2034 warning in release-please)
- `git diff --check`