### PR TITLE
ci: sync transient Steep API retry policy to next

### DIFF
--- a/.github/scripts/run_steep_shards.py
+++ b/.github/scripts/run_steep_shards.py
@@ -16,6 +16,8 @@ from typing import Dict, List, Optional
 
 WORKFLOW = "ci.yml"
 SHARD_COUNT = 4
+TRANSIENT_HTTP_STATUSES = frozenset({502, 503, 504})
+MAX_API_ATTEMPTS = 4
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 CORRELATION_RE = re.compile(r"^[0-9]+-[0-9]+-[0-9a-f]{40}$")
 
@@ -58,13 +60,22 @@ class GitHubActionsApi:
                 "X-GitHub-Api-Version": "2022-11-28",
             },
         )
-        try:
-            with urllib.request.urlopen(request, timeout=30) as response:
-                body = response.read()
-                return None if not body else json.loads(body.decode())
-        except urllib.error.HTTPError as error:
-            body = error.read().decode(errors="replace")
-            raise ApiError(error.code, body) from error
+        for attempt in range(MAX_API_ATTEMPTS):
+            try:
+                with urllib.request.urlopen(request, timeout=30) as response:
+                    body = response.read()
+                    return None if not body else json.loads(body.decode())
+            except urllib.error.HTTPError as error:
+                body = error.read().decode(errors="replace")
+                should_retry = (
+                    error.code in TRANSIENT_HTTP_STATUSES
+                    and attempt + 1 < MAX_API_ATTEMPTS
+                )
+                if not should_retry:
+                    raise ApiError(error.code, body) from error
+                time.sleep(2 ** (attempt + 1))
+
+        raise AssertionError("unreachable GitHub API retry state")
 
     def dispatch(self, ref: str, inputs: Dict[str, str]) -> None:
         # Ref: https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event

--- a/.github/scripts/test_run_steep_shards.py
+++ b/.github/scripts/test_run_steep_shards.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import importlib.util
+import io
 import tempfile
 import unittest
 from pathlib import Path
@@ -47,6 +48,49 @@ class FakeActionsApi:
 
 
 class RunSteepShardsTest(unittest.TestCase):
+    def test_retries_transient_github_server_errors_with_bounded_backoff(self):
+        module = load_module()
+        api = module.GitHubActionsApi("https://api.github.test", "owner/repo", "token")
+        transient = module.urllib.error.HTTPError(
+            "https://api.github.test", 502, "Server Error", {}, io.BytesIO(b'{"message":"Server Error"}')
+        )
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return b'{"workflow_runs":[]}'
+
+        with (
+            mock.patch.object(module.urllib.request, "urlopen", side_effect=[transient, Response()]) as request,
+            mock.patch.object(module.time, "sleep") as sleep,
+        ):
+            result = api._request("GET", "/actions/runs")
+
+        self.assertEqual(result, {"workflow_runs": []})
+        self.assertEqual(request.call_count, 2)
+        sleep.assert_called_once_with(2)
+
+    def test_does_not_retry_non_transient_github_api_errors(self):
+        module = load_module()
+        api = module.GitHubActionsApi("https://api.github.test", "owner/repo", "token")
+        permanent = module.urllib.error.HTTPError(
+            "https://api.github.test", 422, "Unprocessable", {}, io.BytesIO(b'{"message":"bad request"}')
+        )
+        with (
+            mock.patch.object(module.urllib.request, "urlopen", side_effect=permanent) as request,
+            mock.patch.object(module.time, "sleep") as sleep,
+            self.assertRaises(module.ApiError),
+        ):
+            api._request("POST", "/actions/workflows/ci.yml/dispatches", {})
+
+        self.assertEqual(request.call_count, 1)
+        sleep.assert_not_called()
+
     def test_installs_handlers_so_parent_cancellation_reaches_workers(self):
         module = load_module()
         with mock.patch.object(module.signal, "signal") as install:


### PR DESCRIPTION
## Summary
- sync the validated bounded GitHub API retry policy from `master` to `next`
- keep release-tree attestation exact by aligning trusted CI policy on both production branches

## Provenance
Cherry-pick of master commit `25ec4693e5110cdc0bf7849c8cdcfab7ac1d46ce`, originally reviewed in #355.

## Validation
The source PR passed Ruby tests, RuboCop, Sorbet, Steep, CodeQL, protected paths, and the script unit suite.