### PR TITLE
fix(release): preserve generated gemspec

### DIFF
--- a/.github/scripts/test_release_pr_ci_gate.py
+++ b/.github/scripts/test_release_pr_ci_gate.py
@@ -44,6 +44,21 @@ class RubyReleasePRGateTests(unittest.TestCase):
         self.assertNotIn("release-pr-auto-merge.yml", workflow)
         self.assertNotIn("Dispatch exact-head release PR gate", workflow)
 
+    def test_release_sync_preserves_generated_gemspec(self):
+        workflow = (ROOT / ".github/workflows/release-please.yml").read_text()
+        self.assertNotIn(
+            '"CHANGELOG.md" "lib/telnyx/version.rb" "README.md" "telnyx.gemspec"',
+            workflow,
+        )
+        self.assertNotIn(
+            "for f in CHANGELOG.md lib/telnyx/version.rb README.md telnyx.gemspec",
+            workflow,
+        )
+        self.assertIn(
+            'cmp --silent telnyx.gemspec <(git show origin/next:telnyx.gemspec)',
+            workflow,
+        )
+
     def test_readiness_remains_trusted_dry_run(self):
         workflow = (ROOT / ".github/workflows/release-pr-readiness.yml").read_text()
         self.assertIn("pull_request_target:", workflow)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -107,7 +107,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          RELEASE_FILES=("CHANGELOG.md" "lib/telnyx/version.rb" "README.md" "telnyx.gemspec" ".release-please-manifest.json")
+          # The gemspec is generated SDK code (including runtime dependencies),
+          # not release-only metadata. It must come from next unchanged.
+          RELEASE_FILES=("CHANGELOG.md" "lib/telnyx/version.rb" "README.md" ".release-please-manifest.json")
           git restore --source=refs/remotes/origin/release-base --staged --worktree -- "${RELEASE_FILES[@]}"
           SCAN_TREE=$(git write-tree)
           PROMOTE_SUBJECT=$(git log --format=%s --max-count=50 HEAD \
@@ -173,8 +175,8 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUM: ${{ steps.release-pr.outputs.pr_number }}
         run: |
-          # release-please creates a PR with only version bumps (CHANGELOG,
-          # version.rb, README, gemspec, CHANGELOG.md, .release-please-manifest.json).
+          # release-please creates a PR with release metadata updates (CHANGELOG,
+          # version.rb, README, and .release-please-manifest.json).
           # The actual SDK code changes are on `next` but NOT included in the
           # release PR. This step syncs `next` code into the release PR branch.
           #
@@ -215,7 +217,7 @@ jobs:
 
           # Save version-bump files from the release PR branch (release-please output)
           STASH_DIR=$(mktemp -d)
-          for f in CHANGELOG.md lib/telnyx/version.rb README.md telnyx.gemspec .release-please-manifest.json; do
+          for f in CHANGELOG.md lib/telnyx/version.rb README.md .release-please-manifest.json; do
             if [ -f "$f" ]; then
               mkdir -p "$STASH_DIR/$(dirname "$f")"
               cp "$f" "$STASH_DIR/$f"
@@ -231,7 +233,7 @@ jobs:
           git clean -fdx
 
           # Restore version-bump files from the release PR branch
-          for f in CHANGELOG.md lib/telnyx/version.rb README.md telnyx.gemspec .release-please-manifest.json; do
+          for f in CHANGELOG.md lib/telnyx/version.rb README.md .release-please-manifest.json; do
             if [ -f "$STASH_DIR/$f" ]; then
               mkdir -p "$(dirname "$f")"
               cp "$STASH_DIR/$f" "$f"
@@ -239,6 +241,13 @@ jobs:
             fi
           done
           rm -rf "$STASH_DIR"
+
+          # Runtime dependencies are generated SDK state, never release metadata.
+          # Fail closed if the release sync does not preserve next's exact gemspec.
+          if ! cmp --silent telnyx.gemspec <(git show origin/next:telnyx.gemspec); then
+            echo "::error::Release PR gemspec drifted from next"
+            exit 1
+          fi
 
           # Commit if there are changes
           if git diff --cached --quiet; then


### PR DESCRIPTION
## Root cause
The release sync treated `telnyx.gemspec` as release-only metadata. It restored and re-applied the production copy over the exact `next` tree, so generated runtime dependency removals were lost. This caused `telnyx` 5.165.0 to retain the obsolete `standardwebhooks` dependency even though `next` had removed it.

## Fix
- keep `telnyx.gemspec` from the exact promoted `next` tree
- stop restoring/stashing it as release metadata
- fail closed if the release branch gemspec differs from `origin/next`
- add a static regression contract

## Validation
- RED: new release-sync contract failed against the old workflow
- GREEN: `python3 .github/scripts/test_release_pr_ci_gate.py -v`
- `python3 -m py_compile .github/scripts/test_release_pr_ci_gate.py`
- `git diff --check`

`actionlint` reaches an existing unrelated ShellCheck SC2034 warning in the release assertion block (`attempt` loop variable); the modified shell is otherwise parsed.