### PR TITLE
release: 5.165.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [5.165.0](https://github.com/team-telnyx/telnyx-ruby/compare/v5.165.0...v5.165.0) (2026-09-01)
+
+
+### Features
+
+* promote from staging 9d1efe7 ([ec9acf0](https://github.com/team-telnyx/telnyx-ruby/commit/ec9acf02322e2a47b5410ba78dd81b5734eb927e))
+
+
+### Bug Fixes
+
+* **release:** preserve generated gemspec ([#357](https://github.com/team-telnyx/telnyx-ruby/issues/357)) ([0db381a](https://github.com/team-telnyx/telnyx-ruby/commit/0db381a00236e8a8a5e65a430947415b29e16b8e))
+
 ## [5.165.0](https://github.com/team-telnyx/telnyx-ruby/compare/v5.164.0...v5.165.0) (2026-09-01)
 
 

--- a/telnyx.gemspec
+++ b/telnyx.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |s|
   s.add_dependency "base64"
   s.add_dependency "cgi"
   s.add_dependency "connection_pool"
-  s.add_dependency "standardwebhooks"
 end


### PR DESCRIPTION
Automated Release PR
---


## [5.165.0](https://github.com/team-telnyx/telnyx-ruby/compare/v5.165.0...v5.165.0) (2026-09-01)


### Features

* promote from staging 9d1efe7 ([ec9acf0](https://github.com/team-telnyx/telnyx-ruby/commit/ec9acf02322e2a47b5410ba78dd81b5734eb927e))


### Bug Fixes

* **release:** preserve generated gemspec ([#357](https://github.com/team-telnyx/telnyx-ruby/issues/357)) ([0db381a](https://github.com/team-telnyx/telnyx-ruby/commit/0db381a00236e8a8a5e65a430947415b29e16b8e))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).