### PR TITLE
fix(ci): retry transient GitHub API 500 errors

### DIFF
--- a/.github/scripts/run_steep_shards.py
+++ b/.github/scripts/run_steep_shards.py
@@ -16,7 +16,7 @@ from typing import Dict, List, Optional
 
 WORKFLOW = "ci.yml"
 SHARD_COUNT = 4
-TRANSIENT_HTTP_STATUSES = frozenset({502, 503, 504})
+TRANSIENT_HTTP_STATUSES = frozenset({500, 502, 503, 504})
 MAX_API_ATTEMPTS = 4
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 CORRELATION_RE = re.compile(r"^[0-9]+-[0-9]+-[0-9a-f]{40}$")

--- a/.github/scripts/test_run_steep_shards.py
+++ b/.github/scripts/test_run_steep_shards.py
@@ -50,10 +50,6 @@ class FakeActionsApi:
 class RunSteepShardsTest(unittest.TestCase):
     def test_retries_transient_github_server_errors_with_bounded_backoff(self):
         module = load_module()
-        api = module.GitHubActionsApi("https://api.github.test", "owner/repo", "token")
-        transient = module.urllib.error.HTTPError(
-            "https://api.github.test", 502, "Server Error", {}, io.BytesIO(b'{"message":"Server Error"}')
-        )
 
         class Response:
             def __enter__(self):
@@ -65,15 +61,27 @@ class RunSteepShardsTest(unittest.TestCase):
             def read(self):
                 return b'{"workflow_runs":[]}'
 
-        with (
-            mock.patch.object(module.urllib.request, "urlopen", side_effect=[transient, Response()]) as request,
-            mock.patch.object(module.time, "sleep") as sleep,
-        ):
-            result = api._request("GET", "/actions/runs")
+        for status in (500, 502, 503, 504):
+            with self.subTest(status=status):
+                api = module.GitHubActionsApi("https://api.github.test", "owner/repo", "token")
+                transient = module.urllib.error.HTTPError(
+                    "https://api.github.test",
+                    status,
+                    "Server Error",
+                    {},
+                    io.BytesIO(b'{"message":"Server Error"}'),
+                )
+                with (
+                    mock.patch.object(
+                        module.urllib.request, "urlopen", side_effect=[transient, Response()]
+                    ) as request,
+                    mock.patch.object(module.time, "sleep") as sleep,
+                ):
+                    result = api._request("GET", "/actions/runs")
 
-        self.assertEqual(result, {"workflow_runs": []})
-        self.assertEqual(request.call_count, 2)
-        sleep.assert_called_once_with(2)
+                self.assertEqual(result, {"workflow_runs": []})
+                self.assertEqual(request.call_count, 2)
+                sleep.assert_called_once_with(2)
 
     def test_does_not_retry_non_transient_github_api_errors(self):
         module = load_module()


### PR DESCRIPTION
## Why
Exact-head validation observed a transient GitHub workflow-dispatch HTTP 500. Existing bounded retries covered 502/503/504 but failed immediately on 500.

## Change
- include HTTP 500 in the transient retry set
- retain the four-attempt bound and immediate failure for non-transient statuses
- parameterize the retry contract across 500/502/503/504

## Validation
- RED: the test failed specifically for HTTP 500 before implementation
- `python3 .github/scripts/test_run_steep_shards.py -v`
- Python compilation
- `git diff --check`

This also aligns production with `next` so release PR #362 no longer carries prod-owned CI files.