### PR TITLE
fix(release): remove secrets from release doctor

### DIFF
--- a/.github/scripts/test_release_workflow_hardening.py
+++ b/.github/scripts/test_release_workflow_hardening.py
@@ -62,6 +62,14 @@ class ReleaseWorkflowHardeningTests(unittest.TestCase):
         self.assertIn("--force-with-lease", workflow)
         self.assertNotIn("git push --force origin", workflow)
 
+    def test_release_doctor_does_not_receive_publishing_secrets(self):
+        workflow = Path(".github/workflows/release-doctor.yml").read_text()
+        script = Path("bin/check-release-environment").read_text()
+        self.assertNotIn("secrets.", workflow)
+        for secret_name in ("SDK_WRITE_TOKEN", "RUBYGEMS_HOST", "GEM_HOST_API_KEY"):
+            self.assertNotIn(secret_name, workflow)
+            self.assertNotIn(secret_name, script)
+
     def test_auto_merge_workflow_can_only_attest(self):
         workflow = Path(".github/workflows/release-pr-auto-merge.yml").read_text()
         self.assertIn("--dry-run", workflow)

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -17,7 +17,3 @@ jobs:
       - name: Check release environment
         run: |
           bash ./bin/check-release-environment
-        env:
-          SDK_WRITE_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
-          RUBYGEMS_HOST: ${{ secrets.TELNYX_RUBYGEMS_HOST || secrets.RUBYGEMS_HOST }}
-          GEM_HOST_API_KEY: ${{ secrets.TELNYX_GEM_HOST_API_KEY || secrets.GEM_HOST_API_KEY }}


### PR DESCRIPTION
## Summary
- remove all secret injection from the production Ruby Release Doctor workflow
- add a regression test that prevents publishing credentials from returning
- retain the OIDC publishing workflow unchanged

## Why
SEC-281 requires Release Doctor not to receive package-publishing credentials. This production-owned workflow is restored from `master` during staging promotion, so the canonical `stlc-ruby` generator fix must be paired with this production policy change.

## Validation
- `python3 -m unittest discover -s .github/scripts -p 'test_*.py'` — 77 passed
- `bash -n bin/check-release-environment`
- `git diff --check`

## Related
- SEC-281
- Generator: team-telnyx/stlc-ruby#27
- Dist: team-telnyx/stlc-ruby#28
- Config pin: team-telnyx/telnyx-sdk-config#1036
